### PR TITLE
增加本科生论文封面，修正研究生论文目录前各页，增加主要符号表

### DIFF
--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -510,24 +510,24 @@
 			中图分类号：\buaa@category \hfill 密级\ding{73}~~\buaa@mibao \\
 			论\,\,文\,\,编\,\,号：\buaa@thesisID\\
 		\end{flushleft}
-		\vspace{5em}
-		\includegraphics[width=.55\textwidth]{figure/buaaname.eps}\\
-		\vskip20bp
+		\vskip80bp
+		\includegraphics[width=.5\textwidth]{figure/buaaname.eps}
+		\vskip 10bp
 		\zihao{0}\hwxingkai\centerline{\buaa@appdegree 论文}
-		\vskip 25mm
+		\vskip100bp
 		\begin{minipage}[h]{.8\textwidth}
 			\begin{spacing}{2}
 			\xiaochuhao\songti\centering{\buaa@thesistitle}
 			\end{spacing}
 		\end{minipage}
-		\vfill
-		\heiti\zihao{4}
+		\vskip80bp
+		{\heiti\zihao{4}\ziju{0.2}
 		\begin{tabular}[b]{ll}
-			作\,者\,姓\,名~~ & \buaa@thesisauthor \\
-			学\,科\,专\,业~~ & \buaa@major 专业\\
-			指\,导\,教\,师~~ & \buaa@teacher \\
-			培\,养\,院\,系~~ & \buaa@school 学院\\
-		\end{tabular}
+			作~~者~~姓~~名~~ & \buaa@thesisauthor \\[.4ex]
+			学~~科~~专~~业~~ & \buaa@major 专业\\[.4ex]
+			指~~导~~教~~师~~ & \buaa@teacher \quad\buaa@teacherdegree\\[.4ex]
+			培~~养~~院~~系~~ & \buaa@school 学院\\
+		\end{tabular}}
 	\end{center}
 \end{titlepage}
 
@@ -537,29 +537,26 @@
 \newcommand{\titleeng}{%英文首页
 \clearemptydoublepage
 \thispagestyle{empty}
-\vspace*{\stretch{2}}
+\vspace*{100bp}
 \begin{center}
 	\begin{minipage}[h]{.85\textwidth}
-		\zihao{-2}\centering\textbf{\buaa@thesistitleeng}
+		\centerline{\zihao{-2}\textbf{\buaa@thesistitleeng}}
 	\end{minipage}
-	~~~\\
-	\vspace{\stretch{2}}
-	~~~\\
-	\zihao{4}A Dissertation Submitted for the Degree of \buaa@appdegreeeng\\
-	\vspace{\stretch{4}}
-	\zihao{-3}
+	\vskip100bp
+	{\zihao{4}A Dissertation Submitted for the Degree of \buaa@appdegreeeng}\\
+	\vskip110bp
 	\begin{center}
+	{\zihao{-3}
 		\begin{tabular}{rl}
-			\textbf{Candidate：}&\textbf{\buaa@thesisauthoreng}\\[0.7ex]
+			\textbf{Candidate：}&\textbf{\buaa@thesisauthoreng}\\[2.5ex]
 			\textbf{Supervisor：}&\textbf{\buaa@teacherdegreeeng ~~\buaa@teachereng}
-		\end{tabular}
+		\end{tabular}}
 	\end{center}
 	%这个地方编译后老感觉不是居中的，不知为嘛，或许可以直接在前面加个固定长度而不用列表环境。
 	%加入多余的center环境后编译又会报错，但出来的pdf是正确的，很诡异！
-	\newline
-	\vspace{\stretch{3}}
+	\vskip125bp
 	\zihao{3}{
-	\buaa@schooleng \\
+	\buaa@schooleng \\[1.8ex]
 	\buaa@universityeng , Beijing, China}
 \end{center}
 %说明：使用垂直橡皮长度经常需要加各种空格换行一类的，推荐还是使用vskip来替代
@@ -587,23 +584,21 @@
 \clearemptydoublepage
 \thispagestyle{empty}
 \begin{flushleft}
-	\zihao{5}\heiti
+	{\zihao{5}\heiti
 	中图分类号：\buaa@category\\
-	论\,\,文\,\,编\,\,号：\buaa@thesisID\\
+	论\,\,文\,\,编\,\,号：\buaa@thesisID\\}
 \end{flushleft}
-\zihao{-2}
-\vspace{\stretch{4}}
+\vskip130bp
+\centerline{\zihao{-2}\heiti{\ziju{1.3}\buaa@appdegree 论文}}
+\vskip120bp
 \begin{center}
-	\heiti{\ziju{1.35}\buaa@appdegree 论文}
-	\zihao{5}
-	~~\\
-	\vspace{\stretch{5}}
 	\begin{minipage}[h]{.85\textwidth}
 		\zihao{-1}\heiti\centering{\buaa@thesistitle}
 	\end{minipage}
-	\vspace{\stretch{5}}
 \end{center}
-\zihao{-4}\songti
+\vskip110bp
+\begin{spacing}{2.2}
+{\zihao{-4}\songti
 \begin{tabular}[b]{llll}
 	作\,\,\,\,者\,\,\,\,姓\,\,\,\,名 & \buaa@thesisauthor& 申请学位级别 & \buaa@appdegree \\
 	指导教师姓名 & \buaa@teacher & 职\qquad\qquad 称 & \buaa@teacherdegree \\
@@ -611,13 +606,14 @@
 	学\,\,习\,\,时\,\,间\,自 &\buaa@thesisbeginyear~~年~~\buaa@thesisbeginmonth~~月~~\buaa@thesisbeginday~~日\qquad & 起\qquad 至~  & \buaa@thesisendyear~~年~~\buaa@thesisendmonth~~月~~\buaa@thesisendday~~日止\qquad\\
 	论文提交日期 &\buaa@commityear~~年~~\buaa@commitmonth~~月~~\buaa@commitday~~日\qquad & 论文答辩日期& \buaa@defenseyear~~年~~\buaa@defensemonth~~月~~\buaa@defenseday~~日~\qquad\\
 	学位授予单位 & \buaa@university &学位授予日期 &\buaa@awardyear~~年~~\buaa@awardmonth~~月~~\buaa@awardday~~日~\qquad\\
-\end{tabular}
+\end{tabular}}
+\end{spacing}
 }
 %+++++++++++研究生独创声明和使用授权书++++++++++++++
 \newcommand{\creationanduse}{%
 \clearemptydoublepage
 \thispagestyle{empty}
-\vspace*{30bp}
+\vspace*{50bp}
 \centerline{\zihao{3}\heiti 关于学位论文的独创性声明}
 \zihao{-4}\songti
 ~~\par
@@ -628,9 +624,8 @@
 均已在论文中作出了明确的说明。\par
 若有不实之处，本人愿意承担相关法律责任。\par
 ~~\\
-\zihao{5}{学位论文作者签名：\uline{\hspace{6em}}\hspace{8em}日期：\hspace{7ex}年\hspace{5ex}月\hspace{5ex}日}
-\vspace{90bp}
-\newline
+{\zihao{5}学位论文作者签名：\uline{\hspace{6em}}\hspace{8em}日期：\hspace{7ex}年\hspace{5ex}月\hspace{5ex}日}
+\vskip130bp
 \centerline{\zihao{3}\heiti 学位论文使用授权书}
 ~~\par
 	本人完全同意北京航空航天大学有权使用本学位论文（包括但不限于其印刷版和电子版），
@@ -639,7 +634,7 @@
 或部分内容编入有关数据库进行检索，采用影印、缩印或其他复制手段保存学位论文。\par
 保密学位论文在解密后的使用授权同上。\par
 ~~\\
-\zihao{5}{
+{\zihao{5}
 学位论文作者签名：\uline{\hspace{6em}}\hspace{8em}日期：\hspace{7ex}年\hspace{5ex}月\hspace{5ex}日\\
 指导教师签名：\uline{\hspace{8em}}\hspace{8em}日期：\hspace{7ex}年\hspace{5ex}月\hspace{5ex}日}
 }
@@ -797,7 +792,7 @@
 	\vskip10bp
 	\par
 \else
-	\vspace{3ex}
+	\vspace{5ex}
 \fi
 \setlength{\parindent}{24bp}
 }{%
@@ -827,7 +822,7 @@
 	\vskip10bp
 	\par
 \else
-	\vspace{3ex}
+	\vspace{5ex}
 \fi
 \setlength{\parindent}{24bp}
 }{%
@@ -837,6 +832,24 @@
 \fi
 {\bf\zihao{-4} Key words: }\buaa@ekeyword
 }
+
+%% 主要符号对照表
+%% 来自于武汉理工大学论文模板，不知下面的间距设置是否会对别的地方有影响，待后续检验。
+\newenvironment{denotation}[1][2.5cm]{
+    \chapter*{主~要~符~号~表} % no tocline
+    \noindent\begin{list}{}%
+    {\vskip-30bp\zihao{-4}
+     \renewcommand\makelabel[1]{##1\hfil}
+     \setlength{\labelwidth}{#1} % 标签盒子宽度
+     \setlength{\labelsep}{0.5cm} % 标签与列表文本距离
+     \setlength{\itemindent}{0cm} % 标签缩进量
+     \setlength{\leftmargin}{\labelwidth+\labelsep} % 左边界
+     \setlength{\rightmargin}{0cm}
+     \setlength{\parsep}{0cm} % 段落间距
+     \setlength{\itemsep}{0cm} % 标签间距
+    \setlength{\listparindent}{0cm} % 段落缩进量
+    \setlength{\topsep}{0pt} % 标签与上文的间距
+   }}{\end{list}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %---      以下是写用户手册时需要用到的一新命令     ---

--- a/file/denotation.tex
+++ b/file/denotation.tex
@@ -1,0 +1,22 @@
+\begin{denotation}
+
+\item[HPC] 高性能计算 (High Performance Computing)
+\item[cluster] 集群
+\item[Itanium] 安腾
+\item[SMP] 对称多处理
+\item[API] 应用程序编程接口
+\item[PI]	聚酰亚胺
+\item[MPI]	聚酰亚胺模型化合物，N-苯基邻苯酰亚胺
+\item[PBI]	聚苯并咪唑
+\item[MPBI]	聚苯并咪唑模型化合物，N-苯基苯并咪唑
+\item[PY]	聚吡咙
+\item[PMDA-BDA]	均苯四酸二酐与联苯四胺合成的聚吡咙薄膜
+\item[$\Delta G$]  	活化自由能~(Activation Free Energy)
+\item [$\chi$] 传输系数~(Transmission Coefficient)
+\item[$E$] 能量
+\item[$m$] 质量
+\item[$c$] 光速
+\item[$P$] 概率
+\item[$T$] 时间
+\item[$v$] 速度
+\end{denotation}

--- a/sample-bachelor.tex
+++ b/sample-bachelor.tex
@@ -4,23 +4,23 @@
 %------        用户公共信息            -------
 \thesisauthor{张三}{ZhangSan}
 \thesistitle{基于Texlive的北航毕设论文模板设计}{How to design the BUAA-thesis with \LaTeX{}}
-\school{二逼青年}{The School of 2B}%i怕不怕
-\major{吊丝}{DiaoSi}%专业
+\school{二逼青年}{The School of 2B}  % 学院，不需要添加“学院”二字
+\major{吊丝}{DiaoSi}                 % 专业，不需要添加“专业”二字
 \teacher{王小五}{Wang Xiaowu}
-\category{TP312}%中图分类号，可以在http://www.ztflh.com/查询
-\mibao{不涉密}%本科生此项必须写“不涉密”或为空
-\thesisbegin{2011}{1}{1}%本科生为毕设开始时间；研究生为学习开始时间
-\thesisend{2012}{2}{2}%本科生为毕设结束时间；研究生为学习结束时间
-\defense{2012}{07}{05}%毕设答辩时间
+\category{TP312}                    % 中图分类号，可以在http://www.ztflh.com/查询
+\thesisbegin{2011}{1}{1}            % 本科生为毕设开始时间；研究生为学习开始时间
+\thesisend{2012}{2}{2}              % 本科生为毕设结束时间；研究生为学习结束时间
+\defense{2012}{07}{05}              % 毕设答辩时间
 \ckeyword{北航开源俱乐部，\LaTeX{}，论文}
 \ekeyword{BHOSC,\LaTeX{},Thesis}
 
 %--------------本科生的信息--------------------
-\class{3702} % 班级
+\class{3702}         % 班级
 \studentID{12345678} % 学号
-\unicode{10006} % 单位代码
+\unicode{10006}      % 单位代码
 \thesisdate{2012}{6} % 论文时间，用于首页
-\include{file/assign} % 导入任务书内容
+
+\include{file/assign}% 导入任务书内容
 
 \begin{document}
 \maketitle

--- a/sample-master.tex
+++ b/sample-master.tex
@@ -7,28 +7,23 @@
 \thesisauthor{张三}{ZhangSan}
 \thesistitle{基于Texlive的北航毕设论文模板设计}{Design the BUAA-thesis with \LaTeX{}}
 \school{二逼青年}{The School of 2B}%学院
-\major{吊丝}{DiaoSi}%专业
+\major{吊丝}{DiaoSi}            %专业
 \teacher{王小五}{Wang Xiaowu}
-\category{TP312}%中图分类号，可以在http://www.ztflh.com/查询
-\mibao{机密}%本科生此项必须写“不涉密”或为空
-\thesisbegin{2011}{1}{1}%本科生为毕设开始时间；研究生为学习开始时间
-\thesisend{2012}{2}{2}%本科生为毕设结束时间；研究生为学习结束时间
-\defense{2012}{07}{05}%毕设答辩时间
+\category{TP312}               %中图分类号，可以在http://www.ztflh.com/查询
+\thesisbegin{2011}{1}{1}       %本科生为毕设开始时间；研究生为学习开始时间
+\thesisend{2012}{2}{2}         %本科生为毕设结束时间；研究生为学习结束时间
+\defense{2012}{07}{05}         %毕设答辩时间
 \ckeyword{北航开源俱乐部，\LaTeX{}，论文}
 \ekeyword{BHOSC,\LaTeX{},Thesis}
 
-%--------------本科生的信息--------------------
-\class{3702}%班级，在任务书里需要用到
-\studentID{37020000}%学号
-\unicode{10006}%单位代码，北航应该为10006，但手册上说由教务老师统一填写。
-\thesisdate{2012}{6}%论文时间，用于首页
 
 %--------------研究生的信息--------------------
-\direction{搬砖方向}%研究方向
-\teacherdegree{教授}{Prof.}%需要英文？
-\thesisID{10006SY0000000}%论文编号为10006+学号组成
-\commit{2012}{3}{3}%论文提交时间
-\award{2012}{4}{4}%学位授予日期，好奇葩...
+\direction{搬砖}            %研究方向
+\teacherdegree{教授}{Prof.}
+\mibao{机密}                % 保密等级
+\thesisID{10006SY0000000}  % 论文编号为10006+学号组成
+\commit{2012}{3}{3}        %论文提交时间
+\award{2012}{4}{4}         %学位授予日期
 
 %--------------------------------------------
 
@@ -38,7 +33,7 @@
 \tableofcontents
 \listoffigures
 \listoftables
-%此处应该再加入“论文主要符号表”，可参考其他学校的模板中的设计
+\include{file/denotation}
 
 \mainmatter
 \include{file/chapter1-jianjie}	


### PR DESCRIPTION
本科生论文封面基本上满足要求，研究生论文的目录前各页我也只能凭自己的目测来修正相关参数，研究生院给的模板很糟糕。参照武汉理工大学论文模板增加“主要符号表”(研究生)。
