### PR TITLE
change the leftmark in 主要符号对照表

### DIFF
--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -842,7 +842,7 @@ The LaTeX template for thesis of BUAA]
 
 \newenvironment{denotation}
     {
-        \chapter*{主要符号对照表} % no tocline
+        \chapter*{主要符号对照表\markboth{主要符号对照表}{}} % no tocline
         \begin{list}{}%
         {
             \zihao{-4}


### PR DESCRIPTION
\chapter\* doesn't change the leftmark somehow. We have to set it by
hand. This would fix issue #85.
