### PR TITLE
Modify data/com_info.tex for misleading like #106

### DIFF
--- a/data/com_info.tex
+++ b/data/com_info.tex
@@ -41,4 +41,4 @@
 \ckeyword{北航开源俱乐部，\LaTeX{}，论文}
 
 % 英文摘要关键字
-\ekeyword{BHOSC,\LaTeX{},Thesis}
+\ekeyword{BHOSC, \LaTeX{}, Thesis}


### PR DESCRIPTION
- English keywords should have at least one space after each comma
  so that LaTeX can judge linebreak correctly. Current samples
  seem to be misleading.
