### PR TITLE
cls: fix graphicspath

### DIFF
--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -271,7 +271,7 @@ The LaTeX template for thesis of BUAA]
 
 \RequirePackage{graphicx}
 \DeclareGraphicsExtensions{.eps,.ps,.jpg,.bmp}
-\graphicspath{figure/}
+\graphicspath{{figure/}}
 \RequirePackage{pifont} % “秘级”后的五角星
 \RequirePackage{subfigure}
 


### PR DESCRIPTION
In grfguide.pdf, the path should be "A list of directories, each in a {}
group (even if there is only one in the list)".
