### PR TITLE
Add .DS_Store in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.swp
 *.thm
 *.pdf
+.DS_Store


### PR DESCRIPTION
This is an automatically generated file in OS X, which should be ignored.

See http://en.wikipedia.org/wiki/.DS_Store for detailed reasons.
