### PR TITLE
改进图表目录的格式

### DIFF
--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -212,6 +212,15 @@ The LaTeX template for thesis of BUAA]
 \addtocontents{lof}{\protect\noaddvspace}
 \addtocontents{lot}{\protect\noaddvspace}
 
+%表目录图目录的格式设置
+%表目录与图目录数字前增加“表”与“图”字，并且使目录行间距与section行间距一致
+
+\titlecontents{figure}[0pt]{\vspace{0.15\baselineskip}\songti\zihao{-4}}{\makebox[3em][l]{图~\thecontentslabel\quad}}{}
+    {\hspace{.5em}\titlerule*[4pt]{$\cdot$}\contentspage}[\vspace{0.15\baselineskip}]
+
+\titlecontents{table}[0pt]{\vspace{0.15\baselineskip}\songti\zihao{-4}}{\makebox[3em][l]{表~\thecontentslabel\quad}}{}
+    {\hspace{.5em}\titlerule*[4pt]{$\cdot$}\contentspage}[\vspace{0.15\baselineskip}]
+
 %%%%%%%%%% cross reference %%%%%%%%%%
 % 交叉引用
 


### PR DESCRIPTION
表目录与图目录增加“表”和”图“字，并且调整目录行间距与toc的section一致

俺小导师看我论文的时候提的，理由是word生成的lof和lot都带有图和表的字样，我这个没有，显然是不按照格式云云

作为一个学渣和小导师对刚我是不敢的，所以就找了个代码试了试（来源找不到了，抱歉），然后我也发现lof和loc的行间距和toc比起来有点小

不知道大家对这个改进怎么看？
