### PR TITLE
根据信息自动更新pdf属性信息

### DIFF
--- a/sample-bachelor.tex
+++ b/sample-bachelor.tex
@@ -6,6 +6,18 @@
 \include{data/com_info}
 \include{data/bachelor/bachelor_info}
 
+% 写入PDF属性信息
+\makeatletter
+\hypersetup{
+    bookmarksnumbered,
+    bookmarksopen,
+    pdftitle={\buaa@thesistitle},
+    pdfauthor={\buaa@thesisauthor},
+    pdfsubject={北京航空航天大学\buaa@degree 毕业设计(论文)},
+    pdfcreator={LaTeXed~By~BHOSC}
+}
+\makeatother
+
 % 任务书信息
 \include{data/bachelor/assign}
 

--- a/sample-master.tex
+++ b/sample-master.tex
@@ -6,6 +6,18 @@
 \include{data/com_info}
 \include{data/master/master_info}
 
+% 写入PDF属性信息
+\makeatletter
+\hypersetup{
+    bookmarksnumbered,
+    bookmarksopen,
+    pdftitle={\buaa@thesistitle},
+    pdfauthor={\buaa@thesisauthor},
+    pdfsubject={北京航空航天大学\buaa@degree 论文},
+    pdfcreator={LaTeXed~By~BHOSC}
+}
+\makeatother
+
 % 中英封面、提名页、授权书
 \maketitle
 % 前言页眉页脚样式


### PR DESCRIPTION
根据已经设置的论文信息自动更新pdf属性信息。之所以在sample文件中更新，是因为在没有输入信息的时候，pdf值都会是空的。

我也试过用`\AtBeginDocument`命令或者`etoolbox`，但是不知为何只有`buaa@degree`的信息能够显示，别的都是空值，所以只能使用这种不够优雅的方法了。

在sample里边的hypersetup会覆盖cls里边的，但是为了保险起见暂时没有删除cls的。

这个先看看各位的看法吧，如果可以的话那么关键字也可以加上去自动更新。
