### PR TITLE
增加了“论文封面”，“摘要”和“目录”三个PDF书签

### DIFF
--- a/data/abstract.tex
+++ b/data/abstract.tex
@@ -1,6 +1,7 @@
 % !Mode:: "TeX:UTF-8"
 
 % 中英文摘要
+\pdfbookmark[1]{摘要}{abstract-zh}
 \begin{cabstract}
 本篇文档主要介绍{\bf 北航毕业设计论文\LaTeX{}模板}使用和相关软件环境的安装配置，
 以及本模板所遵循的开源协议等。

--- a/sample-bachelor.tex
+++ b/sample-bachelor.tex
@@ -11,11 +11,15 @@
 
 % 页眉页脚样式
 \pagestyle{mainmatter}
+
 % 封面、任务书、声明
+\pdfbookmark[0]{Front Matter}{frontmatter}
+\pdfbookmark[1]{论文封面}{titlepage-zh}
 \maketitle
 % 摘要
 \include{data/abstract}
 % 目录
+\pdfbookmark[1]{目 录}{toc}
 \tableofcontents
 % 将表格的行距增大为正常行距
 \renewcommand{\arraystretch}{1.5}

--- a/sample-master.tex
+++ b/sample-master.tex
@@ -7,12 +7,16 @@
 \include{data/master/master_info}
 
 % 中英封面、提名页、授权书
+\pdfbookmark[0]{Front Matter}{frontmatter}
+\pdfbookmark[1]{论文封面}{titlepage-zh}
 \maketitle
+
 % 前言页眉页脚样式
 \pagestyle{frontmatter}
 % 摘要
 \include{data/abstract}
 % 目录、插图目录、表格目录
+\pdfbookmark[1]{目 录}{toc}
 \tableofcontents
 \listoffigures
 \listoftables


### PR DESCRIPTION
只增加pdf书签，不影响实际的**目 录**页面。**目的是便于PDF浏览。**

主要用 `\pdfbookmarks` 命令实现。

**_最终期望**_的效果如下图所示(即把所有的书签都添加完整)：
![bookmarks](https://cloud.githubusercontent.com/assets/2830900/4752953/f6841d5c-5ab1-11e4-8fbf-7580403dd45f.png)
![contents](https://cloud.githubusercontent.com/assets/2830900/4752955/f8b68506-5ab1-11e4-9432-d55b53c8a9f7.png)

目前的尝试中，只有**论文封面**、**摘要**以及**目录**三个pdf书签能够准确定位。其他的的书签定位会有偏差，具体原因可能跟`.cls`文件有关，有待继续改进。
