### PR TITLE
Temporarily disable the bibtex error detection.

### DIFF
--- a/msmake.bat
+++ b/msmake.bat
@@ -45,10 +45,11 @@ call %mythesis%.pdf
 goto end
 :full
 call bibtex %mythesis%
-if errorlevel 1 goto biberr
+:: Negligible errors will occur when build the bib library.
+:: if errorlevel 1 goto biberr
+if not exist %mythesis%.bbl goto biberr
 call xelatex %mythesis%
 call xelatex %mythesis%
-if errorlevel 1 goto myerr1
 echo 成功生成论文
 call %mythesis%.pdf
 goto end


### PR DESCRIPTION
In our `.bst` file, some functions are used before declarations, the bibtex still works well and generates correct `.bbl` file, but errors will be reported. Then the command `msmake.bat bachelor full` will be broke. I disable the return value checking for bibtex command as a fix to this issue. After we throughout fix our `.bst` file. I will enable this error checking.