### PR TITLE
Drop the dependency of hypernat package.

### DIFF
--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -254,7 +254,9 @@ The LaTeX template for thesis of BUAA]
 \RequirePackage[sort&compress]{natbib}
 \bibpunct{[}{]}{,}{n}{}{}
 \setlength{\bibsep}{0pt}
-\RequirePackage{hypernat}
+% New versions of hyperref and natbib don't need hypernat at all.
+% It's not contained in newer version of CTeX distributions.
+\IfFileExists{hypernat.sty}{\RequirePackage{hypernat}}{}
 \newcommand{\upcite}[1]{\textsuperscript{\cite{#1}}}
 
 %%%%%%%%%% table %%%%%%%%%%

--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -254,9 +254,6 @@ The LaTeX template for thesis of BUAA]
 \RequirePackage[sort&compress]{natbib}
 \bibpunct{[}{]}{,}{n}{}{}
 \setlength{\bibsep}{0pt}
-% New versions of hyperref and natbib don't need hypernat at all.
-% It's not contained in newer version of CTeX distributions.
-\IfFileExists{hypernat.sty}{\RequirePackage{hypernat}}{}
 \newcommand{\upcite}[1]{\textsuperscript{\cite{#1}}}
 
 %%%%%%%%%% table %%%%%%%%%%


### PR DESCRIPTION
In newer version of CTeX distribution, the hypernat package is not contained default,  new versions of hyperref and natbib don't need hypernat.

Here is a related discussion: http://tex.stackexchange.com/questions/7340/miktex-2-9-does-not-support-hypernat .