### PR TITLE
Black links

### DIFF
--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -234,7 +234,7 @@ The LaTeX template for thesis of BUAA]
 
 \RequirePackage[xetex,unicode]{hyperref}
 \ifbuaa@color
-    \hypersetup{colorlinks}
+    \hypersetup{colorlinks, linkcolor=black, citecolor=black}
 \else
     \hypersetup{hidelinks}
 \fi


### PR DESCRIPTION
Change cite color and link color to black for batter print quality.