### PR TITLE
Remove [S.l.], [s.n.], etc. in the references

### DIFF
--- a/gbt7714-buaa.bst
+++ b/gbt7714-buaa.bst
@@ -1325,7 +1325,7 @@ FUNCTION {monograph}
   new.sentence
   format.edition output
   new.block
-  format.address.publisher output
+  format.publisher output
   format.year "year" output.check
   format.pages bbl.colon output.after
   format.urldate "" output.after
@@ -1353,7 +1353,7 @@ FUNCTION {incollection}
   new.block
   format.edition output
   new.block
-  format.address.publisher output
+  format.publisher output
   format.year "year" output.check
   format.pages bbl.colon output.after
   format.urldate "" output.after


### PR DESCRIPTION
There are many [S.l.], [s.n.], etc. in the references, because a lot of bib information does not contain these information. In GB/T-7714 2015 standard, [S.l.], [s.n.], etc. seem not necessary. So I suggest to remove them to make the references clearer.