### PR TITLE
Update gbt7714.sty with v2.0.1 and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # BUAAthesis
 
-北航毕设论文LaTeX模板
+北航毕设论文 LaTeX 模板
 
 ## 项目说明
 
-这是北航开源俱乐部维护的的北航毕设论文的LaTeX模板
+这是北航开源俱乐部维护的的北航毕设论文的 LaTeX 模板
 
-目前仍在开发中，欢迎关注进展，提交bug/issue，甚至贡献代码
+目前仍在开发中，欢迎关注进展，提交 bug/issue，甚至贡献代码
 
 ## 预览
 
-项目发布了最新版本的编译好的[PDF样例文档](https://github.com/BHOSC/BUAAthesis/releases/latest)供大家预览：
+项目发布了最新版本的编译好的 [PDF 样例文档](https://github.com/BHOSC/BUAAthesis/releases/latest) 供大家预览：
 
 + 本科：https://github.com/BHOSC/BUAAthesis/releases/download/v0.1/sample-bachelor.pdf
 + 硕士：https://github.com/BHOSC/BUAAthesis/releases/download/v0.1/sample-master.pdf
@@ -18,23 +18,42 @@
 
 ## 最佳实践
 
-**目前学院的要求是毕设论文必须以Word格式提交，这给使用LaTeX
+** 目前学院的要求是毕设论文必须以 Word 格式提交，这给使用 LaTeX
 模板书写毕设论文的同学带来了诸多不便。为此，我们推荐使用在线工
-具将PDF文档转为Word格式：**
+具将 PDF 文档转为 Word 格式：**
 
 [https://cloud.gonitro.com/](https://cloud.gonitro.com/) 需注册，经过尝试本链接效果更好，可以较好处理目录、段落格式和字体等问题。
 
 [http://convertonlinefree.com/PDFToWORDEN.aspx](http://convertonlinefree.com/PDFToWORDEN.aspx)
- 
-**以上链接对公式转换效果均不好，推荐使用pandoc转换或使用其他公式插件进行公式插入**
+
+** 以上链接对公式转换效果均不好，推荐使用 pandoc 转换或使用其他公式插件进行公式插入 **
 
 ## 依赖
 
-模板依赖v2.0及以上版本的ctex包，请使用较新版本的LaTeX发行版。
+模板依赖 v2.0 及以上版本的 ctex 包，请使用较新版本的 LaTeX 发行版。
 
-目前已经测试的LaTeX发行版包括：
+目前已经测试的 LaTeX 发行版包括：
 
-+ TeXLive 2015、TeXLive 2016（**推荐**）
++ TeXLive 2015、TeXLive 2016、TeXLive 2019（** 推荐 **）
 + CTeX 2.9.3
 
-对于老版本的LaTeX发行版，请通过包管理器升级ctex的版本。
+对于老版本的 LaTeX 发行版，请通过包管理器升级 ctex 的版本。
+
+## 使用方法
+
+1. 可以使用命令行或 PowerShell 等，配合项目中的 `mamske.bat` 批处理文件进行编译，详细使用方法请见 `mamske.bat` 文件；
+
+2. 使用 Visual Studio Code 等软件进行编译，请使用 `xelatex->bibtex->xelatex*2` 方式进行编译；
+
+## 参考文献相关
+
+模板参考文献格式采用国家标准 `GB/T 7714-2005` 《信息与文献 参考文献著录规则》之中描述的格式。代码实现为 `CTeX-org / gbt7714-bibtex-style` v2.0.1[https://github.com/CTeX-org/gbt7714-bibtex-style/](https://github.com/CTeX-org/gbt7714-bibtex-style/)。参考文献详细说明请见该项目 README.md。
+
+参考文献提供两种排序方式，分别为 ` 按出现顺序 `（默认）和 ` 按作者姓名和年份 `，请按需在模板 `data\reference.tex` 中做相应修改。
+
+注意：根据 `GB/T 7714-2005` 中 `8.4 节 出版项 ` 中相关规定：
+
++ 无出版地的中文文献著录 “出版地不详”，外文文献著录 “S.l.”
++ 无出版者的中文文献著录 “出版者不详”，外文文献著录 “s.n.”
+
+实际使用中应避免出现 `［S.l.］:［s.n.］` 这样的著录形式。

--- a/README.md
+++ b/README.md
@@ -43,11 +43,18 @@
 
 1. 可以使用命令行或 PowerShell 等，配合项目中的 `mamske.bat` 批处理文件进行编译，详细使用方法请见 `mamske.bat` 文件；
 
-2. 使用 Visual Studio Code 等软件进行编译，请使用 `xelatex->bibtex->xelatex*2` 方式进行编译；
+2. 使用 Makefile，需要所使用的命令行环境支持 Make，cd 到 BUAAthesis 相应目录，目前支持以下功能
+
++ `make bachelor` # 编译本科生的 LATEX（文件默认项，亦可直接输入 make）
++ `make master` # 编译研究生的 LATEX 文件
++ `make clean` # 删除编译过程中生成的文件（除了 pdf）
++ `make depclean` # 删除编译过程中生成的文件（包括 pdf）
+
+3. 使用 Visual Studio Code 等软件进行编译，请使用 `xelatex->bibtex->xelatex*2` 方式进行编译；
 
 ## 参考文献相关
 
-模板参考文献格式采用国家标准 `GB/T 7714-2005` 《信息与文献 参考文献著录规则》之中描述的格式。代码实现为 `CTeX-org / gbt7714-bibtex-style` v2.0.1[https://github.com/CTeX-org/gbt7714-bibtex-style/](https://github.com/CTeX-org/gbt7714-bibtex-style/)。参考文献详细说明请见该项目 README.md。
+模板参考文献格式采用国家标准 `GB/T 7714-2005` 《信息与文献 参考文献著录规则》之中描述的格式。代码实现为 `CTeX-org / gbt7714-bibtex-style` v2.0.1[https://github.com/CTeX-org/gbt7714-bibtex-style/](https://github.com/CTeX-org/gbt7714-bibtex-style/)。参考文献详细说明请见该项目 README.md 或 [https://mirror.ctan.org/biblio/bibtex/contrib/gbt7714/gbt7714.pdf](https://mirror.ctan.org/biblio/bibtex/contrib/gbt7714/gbt7714.pdf)。
 
 参考文献提供两种排序方式，分别为 ` 按出现顺序 `（默认）和 ` 按作者姓名和年份 `，请按需在模板 `data\reference.tex` 中做相应修改。
 
@@ -55,5 +62,10 @@
 
 + 无出版地的中文文献著录 “出版地不详”，外文文献著录 “S.l.”
 + 无出版者的中文文献著录 “出版者不详”，外文文献著录 “s.n.”
+
+相应的解决方法为
+
++ 若编译的参考文献条目中出现 “出版地不详” 或 “S.l.”，请在相应的 bib 条目中添加 address 相关信息
++ 若编译的参考文献条目中出现 “出版者不详” 或 “s.n.”，请在相应的 bib 条目中添加 publisher 相关信息
 
 实际使用中应避免出现 `［S.l.］:［s.n.］` 这样的著录形式。

--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -6,9 +6,9 @@
 
 \NeedsTeXFormat{LaTeX2e}[2007/10/19]
 \ProvidesClass{buaathesis}
-              [2012/07/06 v0.8
+              [2020/03/05 v0.9
 The LaTeX template for thesis of BUAA]
-\typeout{Document Class `buaathesis' v0.8 by BHOSC (2012/07)}
+\typeout{Document Class `buaathesis' v0.9 by BHOSC (2020/03)}
 
 %%%%%%%%%% class options %%%%%%%%%%
 % 模板选项
@@ -254,8 +254,6 @@ The LaTeX template for thesis of BUAA]
 
 %%%%%%%%%% reference %%%%%%%%%%
 % 参考文献
-
-%\bibliographystyle{buaathesis} % 参考文献格式
 \RequirePackage[sort&compress]{natbib}
 \bibpunct{[}{]}{,}{n}{}{}
 \setlength{\bibsep}{0pt}

--- a/data/reference.tex
+++ b/data/reference.tex
@@ -3,13 +3,5 @@
 \phantomsection
 \addcontentsline{toc}{chapter}{参考文献}
 \nocite{*}
-
-% ======Ordering======
-% You can change order of references by selecting the following two lines
-
-\bibliographystyle{gbt7714-author-year}
-% \bibliographystyle{gbt7714-numerical}
-% ====================
-
 \bibliography{data/bibs}
 \cleardoublepage

--- a/data/reference.tex
+++ b/data/reference.tex
@@ -3,5 +3,13 @@
 \phantomsection
 \addcontentsline{toc}{chapter}{参考文献}
 \nocite{*}
+
+% ======Ordering======
+% You can change order of references by selecting the following two lines
+
+\bibliographystyle{gbt7714-author-year}
+% \bibliographystyle{gbt7714-numerical}
+% ====================
+
 \bibliography{data/bibs}
 \cleardoublepage

--- a/gbt7714-author-year.bst
+++ b/gbt7714-author-year.bst
@@ -1,16 +1,16 @@
 %%
-%% This is file `gbt7714-unsrt.bst', commit 775608f in the origin repo.
+%% This is file `gbt7714-author-year.bst',
 %% generated with the docstrip utility.
 %%
 %% The original source files were:
 %%
-%% gbt7714.dtx  (with options: `2015,numerical')
+%% gbt7714.dtx  (with options: `2015,authoryear')
 %% -------------------------------------------------------------------
 %% GB/T 7714-2015 BibTeX Style
 %% https://github.com/CTeX-org/gbt7714-bibtex-style
-%% Version: 2019/11/20 v1.1.2
+%% Version: 2020/03/14 v2.0.1
 %% -------------------------------------------------------------------
-%% Copyright (C) 2016-2019 by Zeping Lee <zepinglee AT gmail.com>
+%% Copyright (C) 2016-2020 by Zeping Lee <zepinglee AT gmail.com>
 %% -------------------------------------------------------------------
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
@@ -26,34 +26,55 @@ INTEGERS {
   period.between.author.year
   sentence.case.title
   link.title
+  title.in.journal
   show.mark
   show.medium.type
   slash.for.extraction
   in.booktitle
-  italic.jounal
+  abbreviate.journal
+  italic.journal
   bold.journal.volume
   show.missing.address.publisher
+  space.before.pages
+  only.start.page
   show.url
   show.doi
   show.note
+  show.english.translation
+  lang.zh.order
+  lang.ja.order
+  lang.en.order
+  lang.ru.order
+  lang.other.order
 }
 
 FUNCTION {load.config}
 {
   #1 'uppercase.name :=
   #3 'max.num.authors :=
+  #0 'period.between.author.year :=
   #1 'sentence.case.title :=
   #0 'link.title :=
+  #1 'title.in.journal :=
   #1 'show.mark :=
   #1 'show.medium.type :=
   #1 'slash.for.extraction :=
   #0 'in.booktitle :=
-  #0 'italic.jounal :=
+  #0 'abbreviate.journal :=
+  #0 'italic.journal :=
   #0 'bold.journal.volume :=
   #1 'show.missing.address.publisher :=
+  #0 'space.before.pages :=
+  #0 'only.start.page :=
   #1 'show.url :=
   #1 'show.doi :=
   #0 'show.note :=
+  #0 'show.english.translation :=
+  #1 'lang.zh.order :=
+  #2 'lang.ja.order :=
+  #3 'lang.en.order :=
+  #4 'lang.ru.order :=
+  #5 'lang.other.order :=
 }
 
 ENTRY
@@ -80,6 +101,7 @@ ENTRY
     series
     title
     translator
+    translation
     url
     urldate
     volume
@@ -261,6 +283,12 @@ FUNCTION {output.check}
 FUNCTION {fin.entry}
 { add.period$
   write$
+  show.english.translation entry.lang lang.zh = and
+    { ")"
+      write$
+    }
+    'skip$
+  if$
   newline$
 }
 
@@ -510,7 +538,7 @@ FUNCTION {format.authors}
 { author empty$ not
     { author format.names }
     { "empty author in " cite$ * warning$
-      ""
+      bbl.anonymous
     }
   if$
 }
@@ -852,11 +880,50 @@ FUNCTION {format.series.vol.num.booktitle}
   if$
 }
 
-FUNCTION {format.journal}
-{ journal
-  italic.jounal entry.lang lang.en = and
-    'italicize
+FUNCTION {remove.period}
+{ 't :=
+  "" 's :=
+    { t empty$ not }
+    { t #1 #1 substring$ 'tmp.str :=
+      tmp.str "." = not
+        { s tmp.str * 's := }
+        'skip$
+      if$
+      t #2 global.max$ substring$ 't :=
+    }
+  while$
+  s
+}
+
+FUNCTION {abbreviate}
+{ remove.period
+  't :=
+  t "l" change.case$ 's :=
+  ""
+  s "physical review letters" =
+    { "Phys Rev Lett" }
     'skip$
+  if$
+  's :=
+  s empty$
+    { t }
+    { pop$ s }
+  if$
+}
+
+FUNCTION {format.journal}
+{ journal empty$ not
+    { journal
+      abbreviate.journal
+        'abbreviate
+        'skip$
+      if$
+      italic.journal entry.lang lang.en = and
+        'italicize
+        'skip$
+      if$
+    }
+    { "" }
   if$
 }
 
@@ -1096,7 +1163,12 @@ FUNCTION {hyphenate}
 FUNCTION {format.pages}
 { pages empty$
     { "" }
-    { pages hyphenate }
+    { pages
+      only.start.page
+        'extract.before.dash
+        'hyphenate
+      if$
+    }
   if$
 }
 
@@ -1121,7 +1193,12 @@ FUNCTION {format.journal.number}
 FUNCTION {format.journal.pages}
 { pages empty$
     { "" }
-    { ":\penalty0 " pages hyphenate * }
+    { space.before.pages
+        { ": " }
+        { ":\penalty0 " }
+      if$
+      format.pages *
+    }
   if$
 }
 
@@ -1193,9 +1270,15 @@ FUNCTION {check.url}
 }
 
 FUNCTION {format.url}
+{ entry.url
+}
+
+FUNCTION {output.url}
 { entry.url empty$ not
-    { new.block entry.url }
-    { "" }
+    { new.block
+      entry.url output
+    }
+    'skip$
   if$
 }
 
@@ -1229,7 +1312,7 @@ FUNCTION {is.in.url}
 
 FUNCTION {format.doi}
 { ""
-  doi empty$ not show.doi and
+  doi empty$ not
     { "" 's :=
       doi 't :=
       #0 'numnames :=
@@ -1257,11 +1340,16 @@ FUNCTION {format.doi}
           t #2 global.max$ substring$ 't :=
         }
       while$
-      's :=
-      s empty$ not
-        { new.block s }
-        { "" }
-      if$
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {output.doi}
+{ doi empty$ not show.doi and
+  show.english.translation entry.lang lang.zh = and not and
+    { new.block
+      format.doi output
     }
     'skip$
   if$
@@ -1293,6 +1381,30 @@ FUNCTION {format.note}
   if$
 }
 
+FUNCTION {output.translation}
+{ show.english.translation entry.lang lang.zh = and
+    { translation empty$ not
+        { translation }
+        { "[English translation missing!]" }
+      if$
+      " (in Chinese)" * output
+      write$
+      format.doi duplicate$ empty$ not
+        { newline$
+          write$
+        }
+        'pop$
+      if$
+      " \\" write$
+      newline$
+      "(" write$
+      ""
+      before.all 'output.state :=
+    }
+    'skip$
+  if$
+}
+
 FUNCTION {empty.misc.check}
 { author empty$ title empty$
   year empty$
@@ -1305,17 +1417,23 @@ FUNCTION {empty.misc.check}
 
 FUNCTION {monograph}
 { output.bibitem
+  output.translation
   author empty$ not
     { format.authors }
     { editor empty$ not
         { format.editors }
         { "empty author and editor in " cite$ * warning$
-          ""
+          bbl.anonymous
         }
       if$
     }
   if$
   output
+  period.between.author.year
+    'new.sentence
+    'skip$
+  if$
+  format.year "year" output.check
   new.block
   format.series.vol.num.title "title" output.check
   "M" set.entry.mark
@@ -1325,12 +1443,11 @@ FUNCTION {monograph}
   new.sentence
   format.edition output
   new.block
-  format.publisher output
-  format.year "year" output.check
+  format.address.publisher output
   format.pages bbl.colon output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1338,8 +1455,14 @@ FUNCTION {monograph}
 
 FUNCTION {incollection}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  period.between.author.year
+    'new.sentence
+    'skip$
+  if$
+  format.year "year" output.check
   new.block
   format.title "title" output.check
   "M" set.entry.mark
@@ -1353,12 +1476,11 @@ FUNCTION {incollection}
   new.block
   format.edition output
   new.block
-  format.publisher output
-  format.year "year" output.check
+  format.address.publisher output
   format.pages bbl.colon output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1366,8 +1488,14 @@ FUNCTION {incollection}
 
 FUNCTION {periodical}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  period.between.author.year
+    'new.sentence
+    'skip$
+  if$
+  format.year "year" output.check
   new.block
   format.title "title" output.check
   "J" set.entry.mark
@@ -1376,10 +1504,9 @@ FUNCTION {periodical}
   format.periodical.year.volume.number output
   new.block
   format.address.publisher output
-  format.date "year" output.check
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1387,21 +1514,30 @@ FUNCTION {periodical}
 
 FUNCTION {article}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  period.between.author.year
+    'new.sentence
+    'skip$
+  if$
+  format.year "year" output.check
   new.block
-  format.title "title" output.check
-  "J" set.entry.mark
-  format.mark "" output.after
-  new.block
+  title.in.journal
+    { format.title "title" output.check
+      "J" set.entry.mark
+      format.mark "" output.after
+      new.block
+    }
+    'skip$
+  if$
   format.journal "journal" output.check
-  format.date "year" output.check
   format.journal.volume output
   format.journal.number "" output.after
   format.journal.pages "" output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1409,8 +1545,14 @@ FUNCTION {article}
 
 FUNCTION {patent}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  period.between.author.year
+    'new.sentence
+    'skip$
+  if$
+  format.year "year" output.check
   new.block
   format.title "title" output.check
   "P" set.entry.mark
@@ -1418,8 +1560,8 @@ FUNCTION {patent}
   new.block
   format.date "year" output.check
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1429,23 +1571,25 @@ FUNCTION {electronic}
 { #1 #1 check.electronic
   #1 'entry.is.electronic :=
   output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  period.between.author.year
+    'new.sentence
+    'skip$
+  if$
+  format.year "year" output.check
   new.block
   format.series.vol.num.title "title" output.check
   "EB" set.entry.mark
   format.mark "" output.after
   new.block
   format.address.publisher output
-  date empty$
-    { format.date output }
-    'skip$
-  if$
   format.pages bbl.colon output.after
   format.editdate "" output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1740,14 +1884,139 @@ FUNCTION {calc.label}
   'label :=
 }
 
-INTEGERS { seq.num }
+FUNCTION {sort.language.label}
+{ entry.lang lang.zh =
+    { lang.zh.order }
+    { entry.lang lang.ja =
+        { lang.ja.order }
+        { entry.lang lang.en =
+            { lang.en.order }
+            { entry.lang lang.ru =
+                { lang.ru.order }
+                { lang.other.order }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+  int.to.chr$
+}
 
-FUNCTION {init.seq}
-{ #0 'seq.num :=}
+FUNCTION {sort.format.names}
+{ 's :=
+  #1 'nameptr :=
+  ""
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    {
+      s nameptr "{vv{ } }{ll{ }}{  ff{ }}{  jj{ }}" format.name$ 't :=
+      nameptr #1 >
+        {
+          "   "  *
+          namesleft #1 = t "others" = and
+            { "zzzzz" * }
+            { numnames #2 > nameptr #2 = and
+                { "zz" * year field.or.null * "   " * }
+                'skip$
+              if$
+              t sortify *
+            }
+          if$
+        }
+        { t sortify * }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
 
-FUNCTION {int.to.fix}
-{ "000000000" swap$ int.to.str$ *
-  #-1 #10 substring$
+FUNCTION {sort.format.title}
+{ 't :=
+  "A " #2
+    "An " #3
+      "The " #4 t chop.word
+    chop.word
+  chop.word
+  sortify
+  #1 global.max$ substring$
+}
+
+FUNCTION {anonymous.sort}
+{ entry.lang lang.zh =
+    { "yi4 ming2" }
+    { "anon" }
+  if$
+}
+
+FUNCTION {warn.empty.key}
+{ entry.lang lang.zh =
+    { "empty key in " cite$ * warning$ }
+    'skip$
+  if$
+}
+
+FUNCTION {author.sort}
+{ key empty$
+    { warn.empty.key
+      author empty$
+        { anonymous.sort }
+        { author sort.format.names }
+      if$
+    }
+    { key sortify }
+  if$
+}
+
+FUNCTION {author.editor.sort}
+{ key empty$
+    { warn.empty.key
+      author empty$
+        { editor empty$
+            { anonymous.sort }
+            { editor sort.format.names }
+          if$
+        }
+        { author sort.format.names }
+      if$
+    }
+    { key sortify }
+  if$
+}
+
+FUNCTION {author.organization.sort}
+{ key empty$
+    { warn.empty.key
+      author empty$
+        { organization empty$
+            { anonymous.sort }
+            { "The " #4 organization chop.word sortify }
+          if$
+        }
+        { author sort.format.names }
+      if$
+    }
+    { key sortify }
+  if$
+}
+
+FUNCTION {editor.organization.sort}
+{ key empty$
+    { warn.empty.key
+      editor empty$
+        { organization empty$
+            { anonymous.sort }
+            { "The " #4 organization chop.word sortify }
+          if$
+        }
+        { editor sort.format.names }
+      if$
+    }
+    { key sortify }
+  if$
 }
 
 FUNCTION {presort}
@@ -1758,8 +2027,29 @@ FUNCTION {presort}
   label sortify
   "    "
   *
-  seq.num #1 + 'seq.num :=
-  seq.num  int.to.fix
+  sort.language.label
+  type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.sort
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
+        'editor.organization.sort
+        'author.sort
+      if$
+    }
+  if$
+  *
+  "    "
+  *
+  year field.or.null sortify
+  *
+  "    "
+  *
+  cite$
+  *
+  #1 entry.max$ substring$
   'sort.label :=
   sort.label *
   #1 entry.max$ substring$
@@ -1822,14 +2112,16 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\url}[1]{#1}"
   write$ newline$
-  "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
+  "\expandafter\ifx\csname urlstyle\endcsname\relax\else"
   write$ newline$
   "  \urlstyle{same}\fi"
   write$ newline$
   show.doi
-    { "\providecommand{\href}[2]{\url{#2}}"
+    { "\expandafter\ifx\csname href\endcsname\relax"
       write$ newline$
-      "\providecommand{\doi}[1]{\href{https://doi.org/#1}{#1}}"
+      "  \DeclareUrlCommand\doi{\urlstyle{rm}}\else"
+      write$ newline$
+      "  \providecommand\doi[1]{\href{https://doi.org/#1}{\nolinkurl{#1}}}\fi"
       write$ newline$
     }
     'skip$
@@ -1846,8 +2138,6 @@ READ
 EXECUTE {init.state.consts}
 
 EXECUTE {load.config}
-
-EXECUTE {init.seq}
 
 ITERATE {presort}
 

--- a/gbt7714-numerical.bst
+++ b/gbt7714-numerical.bst
@@ -1,0 +1,1983 @@
+%%
+%% This is file `gbt7714-numerical.bst',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% gbt7714.dtx  (with options: `2015,numerical')
+%% -------------------------------------------------------------------
+%% GB/T 7714-2015 BibTeX Style
+%% https://github.com/CTeX-org/gbt7714-bibtex-style
+%% Version: 2020/03/14 v2.0.1
+%% -------------------------------------------------------------------
+%% Copyright (C) 2016-2020 by Zeping Lee <zepinglee AT gmail.com>
+%% -------------------------------------------------------------------
+%% This file may be distributed and/or modified under the
+%% conditions of the LaTeX Project Public License, either version 1.3c
+%% of this license or (at your option) any later version.
+%% The latest version of this license is in
+%%    https://www.latex-project.org/lppl.txt
+%% and version 1.3c or later is part of all distributions of LaTeX
+%% version 2005/12/01 or later.
+%% -------------------------------------------------------------------
+INTEGERS {
+  uppercase.name
+  max.num.authors
+  period.between.author.year
+  sentence.case.title
+  link.title
+  title.in.journal
+  show.mark
+  show.medium.type
+  slash.for.extraction
+  in.booktitle
+  abbreviate.journal
+  italic.journal
+  bold.journal.volume
+  show.missing.address.publisher
+  space.before.pages
+  only.start.page
+  show.url
+  show.doi
+  show.note
+  show.english.translation
+}
+
+FUNCTION {load.config}
+{
+  #1 'uppercase.name :=
+  #3 'max.num.authors :=
+  #1 'sentence.case.title :=
+  #0 'link.title :=
+  #1 'title.in.journal :=
+  #1 'show.mark :=
+  #1 'show.medium.type :=
+  #1 'slash.for.extraction :=
+  #0 'in.booktitle :=
+  #0 'abbreviate.journal :=
+  #0 'italic.journal :=
+  #0 'bold.journal.volume :=
+  #1 'show.missing.address.publisher :=
+  #0 'space.before.pages :=
+  #0 'only.start.page :=
+  #1 'show.url :=
+  #1 'show.doi :=
+  #0 'show.note :=
+  #0 'show.english.translation :=
+}
+
+ENTRY
+  { address
+    author
+    booktitle
+    date
+    doi
+    edition
+    editor
+    howpublished
+    institution
+    journal
+    key
+    language
+    mark
+    medium
+    note
+    number
+    organization
+    pages
+    publisher
+    school
+    series
+    title
+    translator
+    translation
+    url
+    urldate
+    volume
+    year
+  }
+  { entry.lang entry.is.electronic entry.numbered }
+  { label extra.label sort.label short.list entry.mark entry.url }
+
+INTEGERS { output.state before.all mid.sentence after.sentence after.block after.slash }
+
+INTEGERS { lang.zh lang.ja lang.en lang.ru lang.other }
+
+INTEGERS { charptr len }
+
+FUNCTION {init.state.consts}
+{ #0 'before.all :=
+  #1 'mid.sentence :=
+  #2 'after.sentence :=
+  #3 'after.block :=
+  #4 'after.slash :=
+  #3 'lang.zh :=
+  #4 'lang.ja :=
+  #1 'lang.en :=
+  #2 'lang.ru :=
+  #0 'lang.other :=
+}
+
+FUNCTION {bbl.anonymous}
+{ entry.lang lang.zh =
+    { "佚名" }
+    { "Anon" }
+  if$
+}
+
+FUNCTION {bbl.space}
+{ entry.lang lang.zh =
+    { "\ " }
+    { " " }
+  if$
+}
+
+FUNCTION {bbl.et.al}
+{ entry.lang lang.zh =
+    { "等" }
+    { entry.lang lang.ja =
+        { "他" }
+        { entry.lang lang.ru =
+            { "идр" }
+            { "et~al." }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {citation.et.al}
+{ bbl.et.al }
+
+FUNCTION {bbl.colon} { ": " }
+
+FUNCTION {bbl.wide.space} { "\quad " }
+
+FUNCTION {bbl.slash} { "//\allowbreak " }
+
+FUNCTION {bbl.sine.loco}
+{ entry.lang lang.zh =
+    { "[出版地不详]" }
+    { "[S.l.]" }
+  if$
+}
+
+FUNCTION {bbl.sine.nomine}
+{ entry.lang lang.zh =
+    { "[出版者不详]" }
+    { "[s.n.]" }
+  if$
+}
+
+FUNCTION {bbl.sine.loco.sine.nomine}
+{ entry.lang lang.zh =
+    { "[出版地不详: 出版者不详]" }
+    { "[S.l.: s.n.]" }
+  if$
+}
+
+FUNCTION {not}
+{   { #0 }
+    { #1 }
+  if$
+}
+
+FUNCTION {and}
+{   'skip$
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {or}
+{   { pop$ #1 }
+    'skip$
+  if$
+}
+
+STRINGS { s t }
+
+FUNCTION {output.nonnull}
+{ 's :=
+  output.state mid.sentence =
+    { ", " * write$ }
+    { output.state after.block =
+        { add.period$ write$
+          newline$
+          "\newblock " write$
+        }
+        { output.state before.all =
+            'write$
+            { output.state after.slash =
+                { bbl.slash * write$
+                  newline$
+                }
+                { add.period$ " " * write$ }
+              if$
+            }
+          if$
+        }
+      if$
+      mid.sentence 'output.state :=
+    }
+  if$
+  s
+}
+
+FUNCTION {output}
+{ duplicate$ empty$
+    'pop$
+    'output.nonnull
+  if$
+}
+
+FUNCTION {output.after}
+{ 't :=
+  duplicate$ empty$
+    'pop$
+    { 's :=
+      output.state mid.sentence =
+        { t * write$ }
+        { output.state after.block =
+            { add.period$ write$
+              newline$
+              "\newblock " write$
+            }
+            { output.state before.all =
+                'write$
+                { output.state after.slash =
+                    { bbl.slash * write$ }
+                    { add.period$ " " * write$ }
+                  if$
+                }
+              if$
+            }
+          if$
+          mid.sentence 'output.state :=
+        }
+      if$
+      s
+    }
+  if$
+}
+
+FUNCTION {output.check}
+{ 't :=
+  duplicate$ empty$
+    { pop$ "empty " t * " in " * cite$ * warning$ }
+    'output.nonnull
+  if$
+}
+
+FUNCTION {fin.entry}
+{ add.period$
+  write$
+  show.english.translation entry.lang lang.zh = and
+    { ")"
+      write$
+    }
+    'skip$
+  if$
+  newline$
+}
+
+FUNCTION {new.block}
+{ output.state before.all =
+    'skip$
+    { output.state after.slash =
+        'skip$
+        { after.block 'output.state := }
+      if$
+    }
+  if$
+}
+
+FUNCTION {new.sentence}
+{ output.state after.block =
+    'skip$
+    { output.state before.all =
+        'skip$
+        { output.state after.slash =
+            'skip$
+            { after.sentence 'output.state := }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {new.slash}
+{ output.state before.all =
+    'skip$
+    { slash.for.extraction
+        { after.slash 'output.state := }
+        { after.block 'output.state := }
+      if$
+    }
+  if$
+}
+
+FUNCTION {new.block.checka}
+{ empty$
+    'skip$
+    'new.block
+  if$
+}
+
+FUNCTION {new.block.checkb}
+{ empty$
+  swap$ empty$
+  and
+    'skip$
+    'new.block
+  if$
+}
+
+FUNCTION {new.sentence.checka}
+{ empty$
+    'skip$
+    'new.sentence
+  if$
+}
+
+FUNCTION {new.sentence.checkb}
+{ empty$
+  swap$ empty$
+  and
+    'skip$
+    'new.sentence
+  if$
+}
+
+FUNCTION {field.or.null}
+{ duplicate$ empty$
+    { pop$ "" }
+    'skip$
+  if$
+}
+
+FUNCTION {italicize}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "\textit{" swap$ * "}" * }
+  if$
+}
+
+INTEGERS { byte second.byte }
+
+INTEGERS { char.lang tmp.lang }
+
+STRINGS { tmp.str }
+
+FUNCTION {get.str.lang}
+{ 'tmp.str :=
+  lang.other 'tmp.lang :=
+  #1 'charptr :=
+  tmp.str text.length$ #1 + 'len :=
+    { charptr len < }
+    { tmp.str charptr #1 substring$ chr.to.int$ 'byte :=
+      byte #128 <
+        { charptr #1 + 'charptr :=
+          byte #64 > byte #91 < and byte #96 > byte #123 < and or
+            { lang.en 'char.lang := }
+            { lang.other 'char.lang := }
+          if$
+        }
+        { tmp.str charptr #1 + #1 substring$ chr.to.int$ 'second.byte :=
+          byte #224 <
+            { charptr #2 + 'charptr :=
+              byte #207 > byte #212 < and
+              byte #212 = second.byte #176 < and or
+                { lang.ru 'char.lang := }
+                { lang.other 'char.lang := }
+              if$
+            }
+            { byte #240 <
+                { charptr #3 + 'charptr :=
+                  byte #227 > byte #234 < and
+                    { lang.zh 'char.lang := }
+                    { byte #227 =
+                        { second.byte #143 >
+                            { lang.zh 'char.lang := }
+                            { second.byte #128 > second.byte #132 < and
+                                { lang.ja 'char.lang := }
+                                { lang.other 'char.lang := }
+                              if$
+                            }
+                          if$
+                        }
+                        { byte #239 =
+                          second.byte #163 > second.byte #172 < and and
+                            { lang.zh 'char.lang := }
+                            { lang.other 'char.lang := }
+                          if$
+                        }
+                      if$
+                    }
+                  if$
+                }
+                { charptr #4 + 'charptr :=
+                  byte #240 = second.byte #159 > and
+                    { lang.zh 'char.lang := }
+                    { lang.other 'char.lang := }
+                  if$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+      char.lang tmp.lang >
+        { char.lang 'tmp.lang := }
+        'skip$
+      if$
+    }
+  while$
+  tmp.lang
+}
+
+FUNCTION {check.entry.lang}
+{ author field.or.null
+  title field.or.null *
+  get.str.lang
+}
+
+FUNCTION {set.entry.lang}
+{ language empty$
+    { check.entry.lang }
+    { language "english" = language "american" = or language "british" = or
+        { lang.en }
+        { language "chinese" =
+            { lang.zh }
+            { language "japanese" =
+                { lang.ja }
+                { language "russian" =
+                    { lang.ru }
+                    { check.entry.lang }
+                  if$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+  'entry.lang :=
+}
+
+FUNCTION {set.entry.numbered}
+{ type$ "patent" =
+  type$ "standard" = or
+  type$ "techreport" = or
+    { #1 'entry.numbered := }
+    { #0 'entry.numbered := }
+  if$
+}
+
+INTEGERS { nameptr namesleft numnames name.lang }
+
+FUNCTION {format.names}
+{ 's :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
+      nameptr max.num.authors >
+        { bbl.et.al
+          #1 'namesleft :=
+        }
+        { t "others" =
+            { bbl.et.al }
+            { t get.str.lang 'name.lang :=
+              name.lang lang.en =
+                { t #1 "{vv~}{ll}{~f{~}}" format.name$
+                  uppercase.name
+                    { "u" change.case$ }
+                    'skip$
+                  if$
+                  t #1 "{, jj}" format.name$ *
+                }
+                { t #1 "{ll}{ff}" format.name$ }
+              if$
+            }
+          if$
+        }
+      if$
+      nameptr #1 >
+        { ", " swap$ * * }
+        'skip$
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {format.key}
+{ empty$
+    { key field.or.null }
+    { "" }
+  if$
+}
+
+FUNCTION {format.authors}
+{ author empty$ not
+    { author format.names }
+    { "empty author in " cite$ * warning$
+      ""
+    }
+  if$
+}
+
+FUNCTION {format.editors}
+{ editor empty$
+    { "" }
+    { editor format.names }
+  if$
+}
+
+FUNCTION {format.translators}
+{ translator empty$
+    { "" }
+    { translator format.names
+      entry.lang lang.zh =
+        { translator num.names$ #3 >
+            { "译" * }
+            { ", 译" * }
+          if$
+        }
+        'skip$
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.full.names}
+{'s :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
+      t get.str.lang 'name.lang :=
+      name.lang lang.en =
+        { t #1 "{vv~}{ll}" format.name$ 't := }
+        { t #1 "{ll}{ff}" format.name$ 't := }
+      if$
+      nameptr #1 >
+        {
+          namesleft #1 >
+            { ", " * t * }
+            {
+              numnames #2 >
+                { "," * }
+                'skip$
+              if$
+              t "others" =
+                { " et~al." * }
+                { " and " * t * }
+              if$
+            }
+          if$
+        }
+        't
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {author.editor.full}
+{ author empty$
+    { editor empty$
+        { "" }
+        { editor format.full.names }
+      if$
+    }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {author.full}
+{ author empty$
+    { "" }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {editor.full}
+{ editor empty$
+    { "" }
+    { editor format.full.names }
+  if$
+}
+
+FUNCTION {make.full.names}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.full
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
+        'editor.full
+        'author.full
+      if$
+    }
+  if$
+}
+
+FUNCTION {output.bibitem}
+{ newline$
+  "\bibitem[" write$
+  label ")" *
+  make.full.names duplicate$ short.list =
+     { pop$ }
+     { * }
+  if$
+  's :=
+  s text.length$ 'charptr :=
+    { charptr #0 > s charptr #1 substring$ "[" = not and }
+    { charptr #1 - 'charptr := }
+  while$
+  charptr #0 >
+    { "{" s * "}" * }
+    { s }
+  if$
+  "]{" * write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  before.all 'output.state :=
+}
+
+FUNCTION {change.sentence.case}
+{ entry.lang lang.en =
+    { "t" change.case$ }
+    'skip$
+  if$
+}
+
+FUNCTION {add.link}
+{ url empty$ not
+    { "\href{" url * "}{" * swap$ * "}" * }
+    { doi empty$ not
+        { "\href{http://dx.doi.org/" doi * "}{" * swap$ * "}" * }
+        'skip$
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.title}
+{ title empty$
+    { "" }
+    { title
+      sentence.case.title
+        'change.sentence.case
+        'skip$
+      if$
+      entry.numbered number empty$ not and
+        { bbl.colon * number * }
+        'skip$
+      if$
+      link.title
+        'add.link
+        'skip$
+      if$
+    }
+  if$
+}
+
+FUNCTION {tie.or.space.connect}
+{ duplicate$ text.length$ #3 <
+    { "~" }
+    { " " }
+  if$
+  swap$ * *
+}
+
+FUNCTION {either.or.check}
+{ empty$
+    'pop$
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+
+FUNCTION {is.digit}
+{ duplicate$ empty$
+    { pop$ #0 }
+    { chr.to.int$
+      duplicate$ "0" chr.to.int$ <
+      { pop$ #0 }
+      { "9" chr.to.int$ >
+          { #0 }
+          { #1 }
+        if$
+      }
+    if$
+    }
+  if$
+}
+
+FUNCTION {is.number}
+{ 's :=
+  s empty$
+    { #0 }
+    { s text.length$ 'charptr :=
+        { charptr #0 >
+          s charptr #1 substring$ is.digit
+          and
+        }
+        { charptr #1 - 'charptr := }
+      while$
+      charptr not
+    }
+  if$
+}
+
+FUNCTION {format.volume}
+{ volume empty$ not
+    { volume is.number
+        { entry.lang lang.zh =
+            { "第 " volume * " 卷" * }
+            { "volume" volume tie.or.space.connect }
+          if$
+        }
+        { volume }
+      if$
+    }
+    { "" }
+  if$
+}
+
+FUNCTION {format.number}
+{ number empty$ not
+    { number is.number
+        { entry.lang lang.zh =
+            { "第 " number * " 册" * }
+            { "number" number tie.or.space.connect }
+          if$
+        }
+        { number }
+      if$
+    }
+    { "" }
+  if$
+}
+
+FUNCTION {format.volume.number}
+{ volume empty$ not
+    { format.volume }
+    { format.number }
+  if$
+}
+
+FUNCTION {format.title.vol.num}
+{ title
+  sentence.case.title
+    'change.sentence.case
+    'skip$
+  if$
+  entry.numbered
+    { number empty$ not
+        { bbl.colon * number * }
+        'skip$
+      if$
+    }
+    { format.volume.number 's :=
+      s empty$ not
+        { bbl.colon * s * }
+        'skip$
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.series.vol.num.title}
+{ format.volume.number 's :=
+  series empty$ not
+    { series
+      sentence.case.title
+        'change.sentence.case
+        'skip$
+      if$
+      entry.numbered
+        { bbl.wide.space * }
+        { bbl.colon *
+          s empty$ not
+            { s * bbl.wide.space * }
+            'skip$
+          if$
+        }
+      if$
+      title *
+      sentence.case.title
+        'change.sentence.case
+        'skip$
+      if$
+      entry.numbered number empty$ not and
+        { bbl.colon * number * }
+        'skip$
+      if$
+    }
+    { format.title.vol.num }
+  if$
+  link.title
+    'add.link
+    'skip$
+  if$
+}
+
+FUNCTION {format.booktitle.vol.num}
+{ booktitle
+  entry.numbered
+    'skip$
+    { format.volume.number 's :=
+      s empty$ not
+        { bbl.colon * s * }
+        'skip$
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.series.vol.num.booktitle}
+{ format.volume.number 's :=
+  series empty$ not
+    { series bbl.colon *
+      entry.numbered not s empty$ not and
+        { s * bbl.wide.space * }
+        'skip$
+      if$
+      booktitle *
+    }
+    { format.booktitle.vol.num }
+  if$
+  in.booktitle
+    { duplicate$ empty$ not entry.lang lang.en = and
+        { "In: " swap$ * }
+        'skip$
+      if$
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {remove.period}
+{ 't :=
+  "" 's :=
+    { t empty$ not }
+    { t #1 #1 substring$ 'tmp.str :=
+      tmp.str "." = not
+        { s tmp.str * 's := }
+        'skip$
+      if$
+      t #2 global.max$ substring$ 't :=
+    }
+  while$
+  s
+}
+
+FUNCTION {abbreviate}
+{ remove.period
+  't :=
+  t "l" change.case$ 's :=
+  ""
+  s "physical review letters" =
+    { "Phys Rev Lett" }
+    'skip$
+  if$
+  's :=
+  s empty$
+    { t }
+    { pop$ s }
+  if$
+}
+
+FUNCTION {format.journal}
+{ journal empty$ not
+    { journal
+      abbreviate.journal
+        'abbreviate
+        'skip$
+      if$
+      italic.journal entry.lang lang.en = and
+        'italicize
+        'skip$
+      if$
+    }
+    { "" }
+  if$
+}
+
+FUNCTION {set.entry.mark}
+{ entry.mark empty$ not
+    'pop$
+    { mark empty$ not
+        { pop$ mark 'entry.mark := }
+        { 'entry.mark := }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.mark}
+{ show.mark
+    { entry.mark
+      show.medium.type
+        { medium empty$ not
+            { "/" * medium * }
+            { entry.is.electronic
+                { "/OL" * }
+                'skip$
+              if$
+            }
+          if$
+        }
+        'skip$
+      if$
+      'entry.mark :=
+      "\allowbreak[" entry.mark * "]" *
+    }
+    { "" }
+  if$
+}
+
+FUNCTION {num.to.ordinal}
+{ duplicate$ text.length$ 'charptr :=
+  duplicate$ charptr #1 substring$ 's :=
+  s "1" =
+    { "st" * }
+    { s "2" =
+        { "nd" * }
+        { s "3" =
+            { "rd" * }
+            { "th" * }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.edition}
+{ edition empty$
+    { "" }
+    { edition is.number
+        { entry.lang lang.zh =
+            { edition " 版" * }
+            { edition num.to.ordinal " ed." * }
+          if$
+        }
+        { entry.lang lang.en =
+            { edition change.sentence.case 's :=
+              s "Revised" = s "Revised edition" = or
+                { "Rev. ed." }
+                { s " ed." *}
+              if$
+            }
+            { edition }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.publisher}
+{ publisher empty$ not
+    { publisher }
+    { school empty$ not
+        { school }
+        { organization empty$ not
+            { organization }
+            { institution empty$ not
+                { institution }
+                { "" }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.address.publisher}
+{ address empty$ not
+    { address
+      format.publisher empty$ not
+        { bbl.colon * format.publisher * }
+        { entry.is.electronic not show.missing.address.publisher and
+            { bbl.colon * bbl.sine.nomine * }
+            'skip$
+          if$
+        }
+      if$
+    }
+    { entry.is.electronic not show.missing.address.publisher and
+        { format.publisher empty$ not
+            { bbl.sine.loco bbl.colon * format.publisher * }
+            { bbl.sine.loco.sine.nomine }
+          if$
+        }
+        { format.publisher empty$ not
+            { format.publisher }
+            { "" }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {extract.before.dash}
+{ duplicate$ empty$
+    { pop$ "" }
+    { 's :=
+      #1 'charptr :=
+      s text.length$ #1 + 'len :=
+        { charptr len <
+          s charptr #1 substring$ "-" = not
+          and
+        }
+        { charptr #1 + 'charptr := }
+      while$
+      s #1 charptr #1 - substring$
+    }
+  if$
+}
+
+FUNCTION {extract.after.dash}
+{ duplicate$ empty$
+    { pop$ "" }
+    { 's :=
+      #1 'charptr :=
+      s text.length$ #1 + 'len :=
+        { charptr len <
+          s charptr #1 substring$ "-" = not
+          and
+        }
+        { charptr #1 + 'charptr := }
+      while$
+        { charptr len <
+          s charptr #1 substring$ "-" =
+          and
+        }
+        { charptr #1 + 'charptr := }
+      while$
+      s charptr global.max$ substring$
+    }
+  if$
+}
+
+FUNCTION {contains.dash}
+{ duplicate$ empty$
+    { pop$ #0 }
+    { 's :=
+        { s empty$ not
+          s #1 #1 substring$ "-" = not
+          and
+        }
+        { s #2 global.max$ substring$ 's := }
+      while$
+      s empty$ not
+    }
+  if$
+}
+
+FUNCTION {format.year}
+{ year empty$ not
+    { year extract.before.dash }
+    { date empty$ not
+        { date extract.before.dash }
+        { "empty year in " cite$ * warning$
+          urldate empty$ not
+            { "[" urldate extract.before.dash * "]" * }
+            { "" }
+          if$
+        }
+      if$
+    }
+  if$
+  extra.label *
+}
+
+FUNCTION {format.date}
+{ type$ "patent" = type$ "newspaper" = or
+  date empty$ not and
+    { date }
+    { year }
+  if$
+}
+
+FUNCTION {format.editdate}
+{ date empty$ not
+    { "\allowbreak(" date * ")" * }
+    { "" }
+  if$
+}
+
+FUNCTION {format.urldate}
+{ urldate empty$ not entry.is.electronic and
+    { "\allowbreak[" urldate * "]" * }
+    { "" }
+  if$
+}
+
+FUNCTION {hyphenate}
+{ 't :=
+  ""
+    { t empty$ not }
+    { t #1 #1 substring$ "-" =
+        { "-" *
+            { t #1 #1 substring$ "-" = }
+            { t #2 global.max$ substring$ 't := }
+          while$
+        }
+        { t #1 #1 substring$ *
+          t #2 global.max$ substring$ 't :=
+        }
+      if$
+    }
+  while$
+}
+
+FUNCTION {format.pages}
+{ pages empty$
+    { "" }
+    { pages
+      only.start.page
+        'extract.before.dash
+        'hyphenate
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.journal.volume}
+{ volume empty$ not
+    { bold.journal.volume
+        { "\textbf{" volume * "}" * }
+        { volume }
+      if$
+    }
+    { "" }
+  if$
+}
+
+FUNCTION {format.journal.number}
+{ number empty$ not
+    { "\penalty0 (" number * ")" * }
+    { "" }
+  if$
+}
+
+FUNCTION {format.journal.pages}
+{ pages empty$
+    { "" }
+    { space.before.pages
+        { ": " }
+        { ":\penalty0 " }
+      if$
+      format.pages *
+    }
+  if$
+}
+
+FUNCTION {format.periodical.year.volume.number}
+{ year empty$ not
+    { year extract.before.dash }
+    { "empty year in periodical " cite$ * warning$ }
+  if$
+  volume empty$ not
+    { ", " * volume extract.before.dash * }
+    'skip$
+  if$
+  number empty$ not
+    { "\penalty0 (" * number extract.before.dash * ")" * }
+    'skip$
+  if$
+  year contains.dash
+    { "--" *
+      year extract.after.dash empty$
+      volume extract.after.dash empty$ and
+      number extract.after.dash empty$ and not
+        { year extract.after.dash empty$ not
+            { year extract.after.dash * }
+            { year extract.before.dash * }
+          if$
+          volume empty$ not
+            { ", " * volume extract.after.dash * }
+            'skip$
+          if$
+          number empty$ not
+            { "\penalty0 (" * number extract.after.dash * ")" * }
+            'skip$
+          if$
+        }
+        'skip$
+      if$
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {check.url}
+{ url empty$ not
+    { "\url{" url * "}" * 'entry.url :=
+      #1 'entry.is.electronic :=
+    }
+    { howpublished empty$ not
+        { howpublished #1 #5 substring$ "\url{" =
+            { howpublished 'entry.url :=
+              #1 'entry.is.electronic :=
+            }
+            'skip$
+          if$
+        }
+        { note empty$ not
+            { note #1 #5 substring$ "\url{" =
+                { note 'entry.url :=
+                  #1 'entry.is.electronic :=
+                }
+                'skip$
+              if$
+            }
+            'skip$
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.url}
+{ entry.url
+}
+
+FUNCTION {output.url}
+{ entry.url empty$ not
+    { new.block
+      entry.url output
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {check.doi}
+{ doi empty$ not
+    { #1 'entry.is.electronic := }
+    'skip$
+  if$
+}
+
+FUNCTION {is.in.url}
+{ 's :=
+  s empty$
+    { #1 }
+    { entry.url empty$
+        { #0 }
+        { s text.length$ 'len :=
+          entry.url text.length$ 'charptr :=
+            { entry.url charptr len substring$ s = not
+              charptr #0 >
+              and
+            }
+            { charptr #1 - 'charptr := }
+          while$
+          charptr
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.doi}
+{ ""
+  doi empty$ not
+    { "" 's :=
+      doi 't :=
+      #0 'numnames :=
+        { t empty$ not}
+        { t #1 #1 substring$ 'tmp.str :=
+          tmp.str "," = tmp.str " " = or t #2 #1 substring$ empty$ or
+            { t #2 #1 substring$ empty$
+                { s tmp.str * 's := }
+                'skip$
+              if$
+              s empty$ s is.in.url or
+                'skip$
+                { numnames #1 + 'numnames :=
+                  numnames #1 >
+                    { ", " * }
+                    { "DOI: " * }
+                  if$
+                  "\doi{" s * "}" * *
+                }
+              if$
+              "" 's :=
+            }
+            { s tmp.str * 's := }
+          if$
+          t #2 global.max$ substring$ 't :=
+        }
+      while$
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {output.doi}
+{ doi empty$ not show.doi and
+  show.english.translation entry.lang lang.zh = and not and
+    { new.block
+      format.doi output
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {check.electronic}
+{ "" 'entry.url :=
+  #0 'entry.is.electronic :=
+    'check.doi
+    'skip$
+  if$
+    'check.url
+    'skip$
+  if$
+  medium empty$ not
+    { medium "MT" = medium "DK" = or medium "CD" = or medium "OL" = or
+        { #1 'entry.is.electronic := }
+        'skip$
+      if$
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {format.note}
+{ note empty$ not show.note and
+    { note }
+    { "" }
+  if$
+}
+
+FUNCTION {output.translation}
+{ show.english.translation entry.lang lang.zh = and
+    { translation empty$ not
+        { translation }
+        { "[English translation missing!]" }
+      if$
+      " (in Chinese)" * output
+      write$
+      format.doi duplicate$ empty$ not
+        { newline$
+          write$
+        }
+        'pop$
+      if$
+      " \\" write$
+      newline$
+      "(" write$
+      ""
+      before.all 'output.state :=
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {empty.misc.check}
+{ author empty$ title empty$
+  year empty$
+  and and
+  key empty$ not and
+    { "all relevant fields are empty in " cite$ * warning$ }
+    'skip$
+  if$
+}
+
+FUNCTION {monograph}
+{ output.bibitem
+  output.translation
+  author empty$ not
+    { format.authors }
+    { editor empty$ not
+        { format.editors }
+        { "empty author and editor in " cite$ * warning$
+          ""
+        }
+      if$
+    }
+  if$
+  output
+  new.block
+  format.series.vol.num.title "title" output.check
+  "M" set.entry.mark
+  format.mark "" output.after
+  new.block
+  format.translators output
+  new.sentence
+  format.edition output
+  new.block
+  format.address.publisher output
+  format.year "year" output.check
+  format.pages bbl.colon output.after
+  format.urldate "" output.after
+  output.url
+  output.doi
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {incollection}
+{ output.bibitem
+  output.translation
+  format.authors output
+  author format.key output
+  new.block
+  format.title "title" output.check
+  "M" set.entry.mark
+  format.mark "" output.after
+  new.block
+  format.translators output
+  new.slash
+  format.editors output
+  new.block
+  format.series.vol.num.booktitle "booktitle" output.check
+  new.block
+  format.edition output
+  new.block
+  format.address.publisher output
+  format.year "year" output.check
+  format.pages bbl.colon output.after
+  format.urldate "" output.after
+  output.url
+  output.doi
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {periodical}
+{ output.bibitem
+  output.translation
+  format.authors output
+  author format.key output
+  new.block
+  format.title "title" output.check
+  "J" set.entry.mark
+  format.mark "" output.after
+  new.block
+  format.periodical.year.volume.number output
+  new.block
+  format.address.publisher output
+  format.date "year" output.check
+  format.urldate "" output.after
+  output.url
+  output.doi
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {article}
+{ output.bibitem
+  output.translation
+  format.authors output
+  author format.key output
+  new.block
+  title.in.journal
+    { format.title "title" output.check
+      "J" set.entry.mark
+      format.mark "" output.after
+      new.block
+    }
+    'skip$
+  if$
+  format.journal "journal" output.check
+  format.date "year" output.check
+  format.journal.volume output
+  format.journal.number "" output.after
+  format.journal.pages "" output.after
+  format.urldate "" output.after
+  output.url
+  output.doi
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {patent}
+{ output.bibitem
+  output.translation
+  format.authors output
+  author format.key output
+  new.block
+  format.title "title" output.check
+  "P" set.entry.mark
+  format.mark "" output.after
+  new.block
+  format.date "year" output.check
+  format.urldate "" output.after
+  output.url
+  output.doi
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {electronic}
+{ #1 #1 check.electronic
+  #1 'entry.is.electronic :=
+  output.bibitem
+  output.translation
+  format.authors output
+  author format.key output
+  new.block
+  format.series.vol.num.title "title" output.check
+  "EB" set.entry.mark
+  format.mark "" output.after
+  new.block
+  format.address.publisher output
+  date empty$
+    { format.date output }
+    'skip$
+  if$
+  format.pages bbl.colon output.after
+  format.editdate "" output.after
+  format.urldate "" output.after
+  output.url
+  output.doi
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {misc}
+{ journal empty$ not
+    'article
+    { booktitle empty$ not
+        'incollection
+        { publisher empty$ not
+            'monograph
+            { entry.is.electronic
+                'electronic
+                { "Z" set.entry.mark
+                  monograph
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+  empty.misc.check
+}
+
+FUNCTION {archive}
+{ "A" set.entry.mark
+  misc
+}
+
+FUNCTION {book} { monograph }
+
+FUNCTION {booklet} { book }
+
+FUNCTION {collection}
+{ "G" set.entry.mark
+  monograph
+}
+
+FUNCTION {database}
+{ "DB" set.entry.mark
+  electronic
+}
+
+FUNCTION {dataset}
+{ "DS" set.entry.mark
+  electronic
+}
+
+FUNCTION {inbook} { book }
+
+FUNCTION {inproceedings}
+{ "C" set.entry.mark
+  incollection
+}
+
+FUNCTION {conference} { inproceedings }
+
+FUNCTION {map}
+{ "CM" set.entry.mark
+  misc
+}
+
+FUNCTION {manual} { monograph }
+
+FUNCTION {mastersthesis}
+{ "D" set.entry.mark
+  monograph
+}
+
+FUNCTION {newspaper}
+{ "N" set.entry.mark
+  article
+}
+
+FUNCTION {online}
+{ "EB" set.entry.mark
+  electronic
+}
+
+FUNCTION {phdthesis} { mastersthesis }
+
+FUNCTION {proceedings}
+{ "C" set.entry.mark
+  monograph
+}
+
+FUNCTION {software}
+{ "CP" set.entry.mark
+  electronic
+}
+
+FUNCTION {standard}
+{ "S" set.entry.mark
+  misc
+}
+
+FUNCTION {techreport}
+{ "R" set.entry.mark
+  misc
+}
+
+FUNCTION {unpublished}
+{ "Z" set.entry.mark
+  misc
+}
+
+FUNCTION {default.type} { misc }
+
+MACRO {jan} {"January"}
+
+MACRO {feb} {"February"}
+
+MACRO {mar} {"March"}
+
+MACRO {apr} {"April"}
+
+MACRO {may} {"May"}
+
+MACRO {jun} {"June"}
+
+MACRO {jul} {"July"}
+
+MACRO {aug} {"August"}
+
+MACRO {sep} {"September"}
+
+MACRO {oct} {"October"}
+
+MACRO {nov} {"November"}
+
+MACRO {dec} {"December"}
+
+MACRO {acmcs} {"ACM Computing Surveys"}
+
+MACRO {acta} {"Acta Informatica"}
+
+MACRO {cacm} {"Communications of the ACM"}
+
+MACRO {ibmjrd} {"IBM Journal of Research and Development"}
+
+MACRO {ibmsj} {"IBM Systems Journal"}
+
+MACRO {ieeese} {"IEEE Transactions on Software Engineering"}
+
+MACRO {ieeetc} {"IEEE Transactions on Computers"}
+
+MACRO {ieeetcad}
+ {"IEEE Transactions on Computer-Aided Design of Integrated Circuits"}
+
+MACRO {ipl} {"Information Processing Letters"}
+
+MACRO {jacm} {"Journal of the ACM"}
+
+MACRO {jcss} {"Journal of Computer and System Sciences"}
+
+MACRO {scp} {"Science of Computer Programming"}
+
+MACRO {sicomp} {"SIAM Journal on Computing"}
+
+MACRO {tocs} {"ACM Transactions on Computer Systems"}
+
+MACRO {tods} {"ACM Transactions on Database Systems"}
+
+MACRO {tog} {"ACM Transactions on Graphics"}
+
+MACRO {toms} {"ACM Transactions on Mathematical Software"}
+
+MACRO {toois} {"ACM Transactions on Office Information Systems"}
+
+MACRO {toplas} {"ACM Transactions on Programming Languages and Systems"}
+
+MACRO {tcs} {"Theoretical Computer Science"}
+
+FUNCTION {sortify}
+{ purify$
+  "l" change.case$
+}
+
+FUNCTION {chop.word}
+{ 's :=
+  'len :=
+  s #1 len substring$ =
+    { s len #1 + global.max$ substring$ }
+    's
+  if$
+}
+
+FUNCTION {format.lab.names}
+{ 's :=
+  s #1 "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
+  t get.str.lang 'name.lang :=
+  name.lang lang.en =
+    { t #1 "{vv~}{ll}" format.name$}
+    { t #1 "{ll}{ff}" format.name$}
+  if$
+  s num.names$ #1 >
+    { bbl.space * citation.et.al * }
+    'skip$
+  if$
+}
+
+FUNCTION {author.key.label}
+{ author empty$
+    { key empty$
+        { cite$ #1 #3 substring$ }
+        'key
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {author.editor.key.label}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { cite$ #1 #3 substring$ }
+            'key
+          if$
+        }
+        { editor format.lab.names }
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {author.key.organization.label}
+{ author empty$
+    { key empty$
+        { organization empty$
+            { cite$ #1 #3 substring$ }
+            { "The " #4 organization chop.word #3 text.prefix$ }
+          if$
+        }
+        'key
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {editor.key.organization.label}
+{ editor empty$
+    { key empty$
+        { organization empty$
+            { cite$ #1 #3 substring$ }
+            { "The " #4 organization chop.word #3 text.prefix$ }
+          if$
+        }
+        'key
+      if$
+    }
+    { editor format.lab.names }
+  if$
+}
+
+FUNCTION {calc.short.authors}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.key.label
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
+        { editor empty$ not
+            'editor.key.organization.label
+            'author.key.organization.label
+          if$
+        }
+        'author.key.label
+      if$
+    }
+  if$
+  'short.list :=
+}
+
+FUNCTION {calc.label}
+{ calc.short.authors
+  short.list
+  "("
+  *
+  format.year duplicate$ empty$
+  short.list key field.or.null = or
+     { pop$ "" }
+     'skip$
+  if$
+  *
+  'label :=
+}
+
+INTEGERS { seq.num }
+
+FUNCTION {init.seq}
+{ #0 'seq.num :=}
+
+FUNCTION {int.to.fix}
+{ "000000000" swap$ int.to.str$ *
+  #-1 #10 substring$
+}
+
+FUNCTION {presort}
+{ set.entry.lang
+  set.entry.numbered
+  show.url show.doi check.electronic
+  calc.label
+  label sortify
+  "    "
+  *
+  seq.num #1 + 'seq.num :=
+  seq.num  int.to.fix
+  'sort.label :=
+  sort.label *
+  #1 entry.max$ substring$
+  'sort.key$ :=
+}
+
+STRINGS { longest.label last.label next.extra }
+
+INTEGERS { longest.label.width last.extra.num number.label }
+
+FUNCTION {initialize.longest.label}
+{ "" 'longest.label :=
+  #0 int.to.chr$ 'last.label :=
+  "" 'next.extra :=
+  #0 'longest.label.width :=
+  #0 'last.extra.num :=
+  #0 'number.label :=
+}
+
+FUNCTION {forward.pass}
+{ last.label label =
+    { last.extra.num #1 + 'last.extra.num :=
+      last.extra.num int.to.chr$ 'extra.label :=
+    }
+    { "a" chr.to.int$ 'last.extra.num :=
+      "" 'extra.label :=
+      label 'last.label :=
+    }
+  if$
+  number.label #1 + 'number.label :=
+}
+
+FUNCTION {reverse.pass}
+{ next.extra "b" =
+    { "a" 'extra.label := }
+    'skip$
+  if$
+  extra.label 'next.extra :=
+  extra.label
+  duplicate$ empty$
+    'skip$
+    { "{\natexlab{" swap$ * "}}" * }
+  if$
+  'extra.label :=
+  label extra.label * 'label :=
+}
+
+FUNCTION {bib.sort.order}
+{ sort.label  'sort.key$ :=
+}
+
+FUNCTION {begin.bib}
+{   preamble$ empty$
+    'skip$
+    { preamble$ write$ newline$ }
+  if$
+  "\begin{thebibliography}{" number.label int.to.str$ * "}" *
+  write$ newline$
+  "\providecommand{\natexlab}[1]{#1}"
+  write$ newline$
+  "\providecommand{\url}[1]{#1}"
+  write$ newline$
+  "\expandafter\ifx\csname urlstyle\endcsname\relax\else"
+  write$ newline$
+  "  \urlstyle{same}\fi"
+  write$ newline$
+  show.doi
+    { "\expandafter\ifx\csname href\endcsname\relax"
+      write$ newline$
+      "  \DeclareUrlCommand\doi{\urlstyle{rm}}\else"
+      write$ newline$
+      "  \providecommand\doi[1]{\href{https://doi.org/#1}{\nolinkurl{#1}}}\fi"
+      write$ newline$
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {end.bib}
+{ newline$
+  "\end{thebibliography}" write$ newline$
+}
+
+READ
+
+EXECUTE {init.state.consts}
+
+EXECUTE {load.config}
+
+EXECUTE {init.seq}
+
+ITERATE {presort}
+
+SORT
+
+EXECUTE {initialize.longest.label}
+
+ITERATE {forward.pass}
+
+REVERSE {reverse.pass}
+
+ITERATE {bib.sort.order}
+
+SORT
+
+EXECUTE {begin.bib}
+
+ITERATE {call.type$}
+
+EXECUTE {end.bib}

--- a/gbt7714.sty
+++ b/gbt7714.sty
@@ -1,5 +1,5 @@
 %%
-%% This is file `gbt7714.sty', commit 775608f in the origin repo.
+%% This is file `gbt7714.sty',
 %% generated with the docstrip utility.
 %%
 %% The original source files were:
@@ -8,9 +8,9 @@
 %% -------------------------------------------------------------------
 %% GB/T 7714-2015 BibTeX Style
 %% https://github.com/CTeX-org/gbt7714-bibtex-style
-%% Version: 2019/11/20 v1.1.2
+%% Version: 2020/03/14 v2.0.1
 %% -------------------------------------------------------------------
-%% Copyright (C) 2016-2019 by Zeping Lee <zepinglee AT gmail.com>
+%% Copyright (C) 2016-2020 by Zeping Lee <zepinglee AT gmail.com>
 %% -------------------------------------------------------------------
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
@@ -22,59 +22,55 @@
 %% -------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesPackage{gbt7714}
-  [2019/11/20 v1.1.2 GB/T 7714-2015 BibTeX Style]
-\newif\if@gbt@mmxv
-\newif\if@gbt@numerical
-\newif\if@gbt@super
-\DeclareOption{2015}{\@gbt@mmxvtrue}
-\DeclareOption{2005}{\@gbt@mmxvfalse}
-\DeclareOption{super}{\@gbt@numericaltrue\@gbt@supertrue}
-\DeclareOption{numbers}{\@gbt@numericaltrue\@gbt@superfalse}
-\DeclareOption{authoryear}{\@gbt@numericalfalse}
+  [2020/03/14 v2.0.1 GB/T 7714-2015 BibTeX Style]
+\newif\ifgbt@legacy@interface
+\newif\ifgbt@mmxv
+\newif\ifgbt@numerical
+\newif\ifgbt@super
+\newcommand\gbt@obselete@option[1]{%
+  \PackageWarning{gbt7714}{The option "#1" is obselete}%
+}
+\DeclareOption{2015}{%
+  \gbt@obselete@option{2015}%
+  \gbt@legacy@interfacetrue
+  \gbt@mmxvtrue
+}
+\DeclareOption{2005}{%
+  \gbt@obselete@option{2005}%
+  \gbt@legacy@interfacetrue
+  \gbt@mmxvfalse
+}
+\DeclareOption{super}{%
+  \gbt@obselete@option{super}%
+  \gbt@legacy@interfacetrue
+  \gbt@numericaltrue
+  \gbt@supertrue
+}
+\DeclareOption{numbers}{%
+  \gbt@obselete@option{numbers}%
+  \gbt@legacy@interfacetrue
+  \gbt@numericaltrue
+  \gbt@superfalse
+}
+\DeclareOption{authoryear}{%
+  \gbt@obselete@option{authoryear}%
+  \gbt@legacy@interfacetrue
+  \gbt@numericalfalse
+}
 \DeclareOption*{\PassOptionsToPackage{\CurrentOption}{natbib}}
-\ExecuteOptions{2015,super}
 \ProcessOptions\relax
-\if@gbt@numerical
-  \PassOptionsToPackage{sort&compress}{natbib}
-\fi
-\RequirePackage{natbib}
+% \RequirePackage[compress]{natbib}
+\setcitestyle{compress}
 \RequirePackage{url}
+\renewcommand\newblock{\space}
 \newcommand\bibstyle@super{\bibpunct{[}{]}{,}{s}{,}{\textsuperscript{,}}}
 \newcommand\bibstyle@numbers{\bibpunct{[}{]}{,}{n}{,}{,}}
 \newcommand\bibstyle@authoryear{\bibpunct{(}{)}{;}{a}{,}{,}}
-\newcommand\gbtbibstyle[1]{%
-  \@ifundefined{gbt@bib@#1}{%
-    \PackageError{gbt7714}{Invalid argument #1}{}%
-  }{%
-    \@nameuse{gbt@bib@#1}
-  }%
-}
-\newcommand\gbt@bib@numerical{%
-  \if@gbt@mmxv
-    \bibliographystyle{gbt7714-buaa}%
-  \else
-    \bibliographystyle{gbt7714-2005-unsrt}%
-  \fi
-}
-\newcommand\gbt@bib@authoryear{%
-  \if@gbt@mmxv
-    \bibliographystyle{gbt7714-plain}%
-  \else
-    \bibliographystyle{gbt7714-2005-plain}%
-  \fi
-}
-\if@gbt@numerical
-  \if@gbt@super
-    \citestyle{super}%
-    \gbtbibstyle{numerical}%
-  \else
-    \citestyle{numbers}
-    \gbtbibstyle{numerical}%
-  \fi
-\else
-  \citestyle{authoryear}
-  \gbtbibstyle{authoryear}%
-\fi
+\newcommand\bibstyle@inline{\bibstyle@numbers}
+\@namedef{bibstyle@gbt7714-numerical}{\bibstyle@super}
+\@namedef{bibstyle@gbt7714-author-year}{\bibstyle@authoryear}
+\@namedef{bibstyle@gbt7714-2005-numerical}{\bibstyle@super}
+\@namedef{bibstyle@gbt7714-2005-author-year}{\bibstyle@authoryear}
 \def\NAT@citexnum[#1][#2]#3{%
   \NAT@reset@parser
   \NAT@sort@cites{#3}%
@@ -268,3 +264,33 @@
   \do\n\do\o\do\p\do\q\do\r\do\s\do\t\do\u\do\v\do\w\do\x\do\y\do\z
 }
 \Urlmuskip=0mu plus 0.1mu
+\newif\ifgbt@bib@style@written
+\@ifpackageloaded{chapterbib}{}{%
+  \def\bibliography#1{%
+    \ifgbt@bib@style@written\else
+      \bibliographystyle{gbt7714-numerical}%
+    \fi
+    \if@filesw
+      \immediate\write\@auxout{\string\bibdata{\zap@space#1 \@empty}}%
+    \fi
+    \@input@{\jobname.bbl}}
+  \def\bibliographystyle#1{%
+    \gbt@bib@style@writtentrue
+    \ifx\@begindocumenthook\@undefined\else
+      \expandafter\AtBeginDocument
+    \fi
+      {\if@filesw
+        \immediate\write\@auxout{\string\bibstyle{#1}}%
+      \fi}%
+  }%
+}
+\ifgbt@legacy@interface
+  \ifgbt@numerical
+    \ifgbt@super\else
+      \citestyle{numbers}
+    \fi
+    \bibliographystyle{gbt7714-numerical}
+  \else
+    \bibliographystyle{gbt7714-author-year}
+  \fi
+\fi

--- a/sample-bachelor.tex
+++ b/sample-bachelor.tex
@@ -1,6 +1,12 @@
 % !Mode:: "TeX:UTF-8"
 \documentclass[bachelor,openany,oneside,color]{buaathesis}
+
+% 参考文献
 \usepackage{gbt7714}
+% 参考文献输出方式，numerical为按照出现顺序，authoryear为按照作者姓名和年份
+\citestyle{numerical}
+% \citestyle{authoryear}
+
 \begin{document}
 
 % 用户信息

--- a/sample-bachelor.tex
+++ b/sample-bachelor.tex
@@ -1,6 +1,6 @@
 % !Mode:: "TeX:UTF-8"
 \documentclass[bachelor,openany,oneside,color]{buaathesis}
-\usepackage[numbers,2015]{gbt7714-buaa}
+\usepackage{gbt7714}
 \begin{document}
 
 % 用户信息

--- a/sample-master.tex
+++ b/sample-master.tex
@@ -1,6 +1,12 @@
 % !Mode:: "TeX:UTF-8"
 \documentclass[master,openright,twoside,color]{buaathesis}
+
+% 参考文献
 \usepackage{gbt7714}
+% 参考文献输出方式，numerical为按照出现顺序，authoryear为按照作者姓名和年份
+\citestyle{numerical}
+% \citestyle{authoryear}
+
 \begin{document}
 
 % 用户信息

--- a/sample-master.tex
+++ b/sample-master.tex
@@ -1,6 +1,6 @@
 % !Mode:: "TeX:UTF-8"
 \documentclass[master,openright,twoside,color]{buaathesis}
-\usepackage[numbers,2015]{gbt7714-buaa}
+\usepackage{gbt7714}
 \begin{document}
 
 % 用户信息


### PR DESCRIPTION
1. Update gbt7714.sty with v2.0.1

In this version I have updated the reference style file using the version 2.0.1 from https://github.com/CTeX-org/gbt7714-bibtex-style/ ,replacing the original v1.1.2. 

The new version of reference style provides additional ranking options. Related change can be seen in data/reference.tex.

2. Update README.md with detailed description of the references
The new version README.md introduces the usage and reference details for user.