### PR TITLE
fix(hansbug): fix english format problem when compiling in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,13 @@ jobs:
         with:
           root_file: ${{ matrix.latex-entry }}.tex
           latexmk_use_xelatex: true
+          latexmk_shell_escape: true
           extra_fonts: |
             ./local_fonts/*
+          pre_compile: |
+            apk add msttcorefonts-installer fontconfig
+            update-ms-fonts
+            fc-cache -f
       - name: Test the compiled file
         run: |
           ls -al *.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,6 @@ jobs:
         run: |
           mkdir -p ./local_fonts
 
-          curl -L 'https://dl.freefontsfamily.com/download/Times-New-Roman-Font/' -o times_new_roman.zip  # download times_new_roman
-          unzip times_new_roman.zip
-          mv 'Times New Roman' times_new_roman
-          mv ./times_new_roman/*.ttf ./local_fonts
-          rm -rf times_new_roman times_new_roman.zip
-
           curl -L 'https://github.com/dolbydu/font/raw/master/unicode/SimSun.ttc' -o ./local_fonts/SimSun.ttc  # download songti
           curl -L 'https://github.com/dolbydu/font/raw/master/unicode/SimHei.ttf' -o ./local_fonts/SimHei.ttf  # download heiti
           curl -L 'https://github.com/dolbydu/font/raw/master/unicode/STXingkai.TTF' -o ./local_fonts/STXingkai.ttf  # download STXingKai


### PR DESCRIPTION
通过在CI虚拟环境中添加预安装指令解决问题，解决方案出处：https://github.com/xu-cheng/latex-action/issues/63#issuecomment-856884815

Fixes #297.
