### PR TITLE
修改列表序号样式

### DIFF
--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -409,8 +409,8 @@ The LaTeX template for thesis of BUAA]
 \RequirePackage{enumitem}
 \setlist{noitemsep}
 \setlist[1,2]{labelindent=\parindent}
-\setlist[enumerate,1]{label=\arabic*、}
-\setlist[enumerate,2]{label=（\arabic*）}
+\setlist[enumerate,1]{label=（\arabic*）}
+\setlist[enumerate,2]{label=（\alph*）}
 \setlist{
     topsep=0pt,
     itemsep=0pt,


### PR DESCRIPTION
校审稿老师给出文章修改意见，说现在列表的编号格式容易与标题号混淆