### PR TITLE
文献引用格式问题和新要求适配

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 .DS_Store
 /local_fonts
 /times_new_roman
+*.fls
+*.synctex(busy)

--- a/buaathesis.cls
+++ b/buaathesis.cls
@@ -894,11 +894,11 @@ The LaTeX template for thesis of BUAA]
     \ifbuaa@bachelor
         \begin{center}
             \begin{minipage}[h]{.75\textwidth}
-                \centering{\zihao{3}\heiti\buaa@thesistitle}
+                \centering{\zihao{-3}\heiti\buaa@thesistitle}
             \end{minipage}
             \begin{minipage}[h]{.8\textwidth}
                 \begin{flushright}
-                    {\zihao{3}\heiti\buaa@thesissubtitle}
+                    {\zihao{-3}\heiti\buaa@thesissubtitle}
                 \end{flushright}
                 % subtitle should be flush right?
             \end{minipage}
@@ -933,7 +933,7 @@ The LaTeX template for thesis of BUAA]
     \ifbuaa@bachelor
         \noindent
     \fi
-    {\heiti\zihao{-4} 关键词：}\heiti\buaa@ckeyword
+    {\heiti\zihao{4} 关键词：}\songti\zihao{-4}\buaa@ckeyword
 }
 
 % 英文摘要
@@ -947,7 +947,7 @@ The LaTeX template for thesis of BUAA]
             \end{minipage}
             \begin{minipage}[h]{.8\textwidth}
                 \begin{flushright}
-                    {\zihao{3}\heiti\buaa@thesissubtitleeng}
+                    {\zihao{-3}\heiti\buaa@thesissubtitleeng}
                 \end{flushright}
             % subtitle should be flushright?
             \end{minipage}
@@ -981,7 +981,7 @@ The LaTeX template for thesis of BUAA]
     \ifbuaa@bachelor
         \noindent
     \fi
-    {\bf\zihao{-4} Key words: }\buaa@ekeyword
+    {\bf\zihao{4} Key words: }\zihao{-4}\buaa@ekeyword
 }
 
 %%%%%%%%%% announce %%%%%%%%%%

--- a/sample-bachelor.tex
+++ b/sample-bachelor.tex
@@ -2,7 +2,7 @@
 \documentclass[bachelor,openany,oneside,color,AutoFakeBold=true]{buaathesis}
 
 % 参考文献
-\usepackage{gbt7714}
+\bibliographystyle{gbt7714-numerical}
 % 参考文献输出方式，numerical为按照出现顺序，authoryear为按照作者姓名和年份
 \citestyle{numerical}
 % \citestyle{authoryear}


### PR DESCRIPTION
如果使用\usepackage{gbt7714}，在Linux下使用Texlive编译会出现如下的错误结果。

![image](https://github.com/BHOSC/BUAAthesis/assets/56832231/14939582-4688-494c-989c-4c4a8fc4c293)

事实上在https://github.com/zepinglee/gbt7714-bibtex-style#%E7%89%88%E6%9C%AC-v20-%E7%9A%84%E9%87%8D%E8%A6%81%E4%BF%AE%E6%94%B9中，已经指出了即将弃用\usepackage{gbt7714}，因此希望更新库中的gbt7714引用方法。

此外，在本科工科的官方模板中，摘要部分论文标题是小三号字，关键字是小四号字，中文关键字是宋体，故而提出修改请求

![image](https://github.com/BHOSC/BUAAthesis/assets/56832231/ba313ac9-d443-4f9e-bb35-42b9e90d707b)

![image](https://github.com/BHOSC/BUAAthesis/assets/56832231/9269d2d7-a1b5-4242-a81f-ed356cdcf186)
